### PR TITLE
MOJITO-865: Consent checkbox.

### DIFF
--- a/app/src/lib/components/payments/CheckoutModal/CheckoutModal.tsx
+++ b/app/src/lib/components/payments/CheckoutModal/CheckoutModal.tsx
@@ -19,7 +19,7 @@ import { Theme, ThemeProvider, createTheme, ThemeOptions, SxProps } from "@mui/m
 import { useShakeAnimation } from "../../../utils/animationUtils";
 import { resetStepperProgress } from "../CheckoutStepper/CheckoutStepper";
 import { continuePlaidOAuthFlow, INITIAL_PLAID_OAUTH_FLOW_STATE, PlaidFlow } from "../../../hooks/usePlaid";
-import { ConsentType } from "../CheckoutModalFooter/CheckoutModalFooter";
+import { ConsentType } from "../../shared/ConsentText/ConsentText";
 
 const SELECTOR_DIALOG_SCROLLABLE = "[role=presentation]";
 
@@ -53,9 +53,9 @@ export interface CheckoutModalProps {
   purchaseInstructions: string;
 
   // Legal:
-  consentType: ConsentType;
-  privacyHref: string;
-  termsOfUseHref: string;
+  consentType?: ConsentType;
+  privacyHref?: string;
+  termsOfUseHref?: string;
 
   // Data:
   orgID: string;

--- a/app/src/lib/components/payments/CheckoutModal/CheckoutModal.tsx
+++ b/app/src/lib/components/payments/CheckoutModal/CheckoutModal.tsx
@@ -366,6 +366,7 @@ export const CheckoutModal: React.FC<CheckoutModalProps> = ({
         onPrev={ handlePrevClicked }
         onClose={ onClose }
         acceptedPaymentTypes={ acceptedPaymentTypes }
+        consentType={ consentType }
         privacyHref={ privacyHref }
         termsOfUseHref={ termsOfUseHref } />
     );

--- a/app/src/lib/components/payments/CheckoutModalFooter/CheckoutModalFooter.tsx
+++ b/app/src/lib/components/payments/CheckoutModalFooter/CheckoutModalFooter.tsx
@@ -1,6 +1,7 @@
 import { Box, Link, Typography, Divider } from "@mui/material";
-import React, { useCallback, useState, Fragment } from "react";
+import React, { useCallback, useState } from "react";
 import { Checkbox } from "../../shared/Checkbox";
+import { ConsentText, ConsentType, CONSENT_ERROR_MESSAGE } from "../../shared/ConsentText/ConsentText";
 import { PrimaryButton } from "../../shared/PrimaryButton/PrimaryButton";
 import { ICONS_BY_VARIANT, LABELS_BY_VARIANT } from "./CheckoutModalFooter.constants";
 
@@ -9,33 +10,7 @@ interface CheckoutModalFooterConsentState {
   isConsentChecked: boolean;
 }
 
-export type ConsentType = "disclaimer" | "checkbox";
 export type CheckoutModalFooterVariant = "toGuestCheckout" | "toPayment" | "toConfirmation" | "toPlaid" | "toForm" | "toMarketplace";
-
-export interface ConsentTextProps {
-  privacyHref?: string;
-  termsOfUseHref?: string;
-}
-
-export const ConsentText: React.FC<ConsentTextProps> = ({
-  privacyHref,
-  termsOfUseHref,
-}) => {
-  const linkElements = [
-    privacyHref ? <Link color="text.primary" href={ privacyHref } target="_blank">Privacy Notices</Link> : null,
-    termsOfUseHref ? <Link color="text.primary" href={ termsOfUseHref } target="_blank">Terms of Use</Link> : null,
-  ].filter(Boolean);
-
-  return (<>
-    have read, understood, and consent to the{" "}
-    { linkElements.map((linkElement, i) => {
-      return <Fragment key={ i }>{ i === linkElements.length - 1 ? "and " : "" }{ linkElement }{ " " }</Fragment>
-    }) }
-    of the sale.
-  </>);
-};
-
-export const CONSENT_ERROR_MESSAGE = "You must accept the terms and conditions of the sale.";
 
 export interface CheckoutModalFooterProps {
   variant: CheckoutModalFooterVariant;
@@ -59,7 +34,7 @@ export const CheckoutModalFooter: React.FC<CheckoutModalFooterProps> = ({
   onCloseClicked,
 }) => {
   // CONSENT:
-  const showConsent = consentType && (variant === "toConfirmation" || variant === "toPlaid");
+  const showConsent = consentType && (privacyHref || termsOfUseHref) && (variant === "toConfirmation" || variant === "toPlaid");
   const consentTextElement = showConsent ? <ConsentText privacyHref={ privacyHref } termsOfUseHref={ termsOfUseHref } /> : null;
 
   const [{

--- a/app/src/lib/components/payments/DisplayBox/DisplayBox.tsx
+++ b/app/src/lib/components/payments/DisplayBox/DisplayBox.tsx
@@ -1,0 +1,25 @@
+import { Theme, SxProps } from "@mui/material/styles";
+import { Box, BoxProps } from "@mui/material";
+
+const DISPLAY_BOX_PROPS: SxProps<Theme> = {
+  p: 2,
+  border: 1,
+  borderRadius: "2px",
+  backgroundColor: theme => theme.palette.grey["50"],
+  borderColor: theme => theme.palette.grey["100"],
+  color: theme => theme.palette.grey["800"],
+  display: "flex",
+  flexDirection: {
+    xs: "column",
+    sm: "row"
+  },
+};
+
+export const DisplayBox: React.FC<BoxProps> = ({
+  sx,
+  ...props
+}) => {
+  return (
+    <Box { ...props } sx={{ ...DISPLAY_BOX_PROPS, ...sx }} />
+  );
+}

--- a/app/src/lib/components/payments/SavedItem/SavedItem.tsx
+++ b/app/src/lib/components/payments/SavedItem/SavedItem.tsx
@@ -5,6 +5,7 @@ import { SecondaryButton } from "../../shared/SecondaryButton/SecondaryButton";
 import { Chip, Stack, Tooltip } from "@mui/material";
 import React, { useCallback } from "react";
 import { ThemeColors } from "../../../domain/mui/mui.interfaces";
+import { DisplayBox } from "../DisplayBox/DisplayBox";
 
 export interface SavedItemLabels {
   active?: string;
@@ -94,22 +95,7 @@ export const SavedItem: React.FC<SavedItemProps> = ({
   }
 
   return (
-    <Box
-      { ...boxProps }
-      sx={{
-        p: 2,
-        border: 1,
-        borderRadius: "2px",
-        backgroundColor: theme => theme.palette.grey["50"],
-        borderColor: theme => theme.palette.grey["100"],
-        color: theme => theme.palette.grey["800"],
-        display: "flex",
-        flexDirection: {
-          xs: "column",
-          sm: "row"
-        },
-        ...boxProps?.sx,
-      }}>
+    <DisplayBox { ...boxProps }>
 
       { variant === "stacked" ? (
         <Box sx={{ flex: 1, pb: 2 }}>
@@ -156,6 +142,6 @@ export const SavedItem: React.FC<SavedItemProps> = ({
         </Stack>
       ) }
 
-    </Box>
+    </DisplayBox>
   );
 };

--- a/app/src/lib/components/shared/Checkbox/index.tsx
+++ b/app/src/lib/components/shared/Checkbox/index.tsx
@@ -1,13 +1,10 @@
-import { SvgIcon } from "@mui/material";
+import { FormControl, FormHelperText, SvgIcon } from "@mui/material";
 import MuiCheckbox, {
   CheckboxProps as MuiCheckboxProps
 } from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import React from "react";
-
-type CheckboxProps = MuiCheckboxProps & {
-  label: string;
-};
+import { Controller } from "react-hook-form";
 
 const CheckboxIconUnchecked = () => (
   <SvgIcon>
@@ -49,24 +46,62 @@ const CheckboxIconChecked = () => (
   </SvgIcon>
 );
 
+export interface CheckboxProps extends MuiCheckboxProps {
+  label: string | number | React.ReactElement;
+  error?: boolean;
+  helperText?: React.ReactNode;
+}
+
 export const Checkbox: React.FC<CheckboxProps> = ({
   label,
   checked,
   onChange,
+  sx,
+  error,
+  helperText,
   ...props
 }) => (
-  <FormControlLabel
-    label={label}
-    control={
-      <MuiCheckbox
-        sx={{ paddingLeft: 1.5, paddingRight: 0.5, paddingTop: 1.5 }}
-        checked={checked}
-        onChange={onChange}
-        icon={<CheckboxIconUnchecked />}
-        checkedIcon={<CheckboxIconChecked />}
-        disableRipple
-        {...props}
-      />
-    }
+  <FormControl sx={ sx } error={ error }>
+    <FormControlLabel
+      label={ label }
+      control={
+        <MuiCheckbox
+          sx={{ paddingLeft: 1.5, paddingRight: 0.5, paddingTop: 1.5 }}
+          checked={checked}
+          onChange={onChange}
+          icon={ <CheckboxIconUnchecked /> }
+          checkedIcon={ <CheckboxIconChecked /> }
+          disableRipple
+          { ...props } />
+      } />
+    { helperText && <FormHelperText>{ helperText }</FormHelperText> }
+  </FormControl>
+);
+
+export const ControlledCheckbox = ({
+  name,
+  control,
+  label,
+}) => (
+  <Controller<{ value: boolean }, "value">
+    name={name}
+    control={control}
+    render={({ field: { name, onChange, ref, value, ...field }, fieldState }) => {
+      const error = fieldState?.error;
+
+      return (
+        <Checkbox
+          id={name}
+          name={name}
+          label={label}
+          checked={value}
+          onChange={onChange}
+          inputRef={ref}
+          error={!!error}
+          helperText={error?.message}
+          {...field}
+        />
+      );
+    }}
   />
 );

--- a/app/src/lib/components/shared/ConsentText/ConsentText.tsx
+++ b/app/src/lib/components/shared/ConsentText/ConsentText.tsx
@@ -1,0 +1,30 @@
+import { Link } from "@mui/material";
+import React, { Fragment } from "react";
+
+export const CONSENT_ERROR_MESSAGE = "You must accept the terms and conditions of the sale.";
+
+export type ConsentType = "disclaimer" | "checkbox";
+
+export interface ConsentTextProps {
+  privacyHref?: string;
+  termsOfUseHref?: string;
+}
+
+export const ConsentText: React.FC<ConsentTextProps> = ({
+  privacyHref,
+  termsOfUseHref,
+}) => {
+  const linkElements = [
+    privacyHref ? <Link color="text.primary" href={ privacyHref } target="_blank">Privacy Notices</Link> : null,
+    termsOfUseHref ? <Link color="text.primary" href={ termsOfUseHref } target="_blank">Terms of Use</Link> : null,
+  ].filter(Boolean);
+
+  return (<>
+    have read, understood, and consent to the{" "}
+    { linkElements.map((linkElement, i) => {
+      return <Fragment key={ i }>{ i === linkElements.length - 1 ? "and " : "" }{ linkElement }{ " " }</Fragment>
+    }) }
+    of the sale.
+  </>);
+};
+

--- a/app/src/lib/components/shared/SavedBillingDetailsSelector/SavedBillingDetailsSelector.tsx
+++ b/app/src/lib/components/shared/SavedBillingDetailsSelector/SavedBillingDetailsSelector.tsx
@@ -74,8 +74,6 @@ export const SavedBillingDetailsSelector: React.FC<SavedBillingDetailsSelectorPr
 
     <CheckoutModalFooter
       variant="toPayment"
-      privacyHref=""
-      termsOfUseHref=""
       onSubmitClicked={ onNext }
       onCloseClicked={ onClose } />
   </>);

--- a/app/src/lib/components/shared/SavedPaymentDetailsSelector/SavedPaymentDetailsSelector.tsx
+++ b/app/src/lib/components/shared/SavedPaymentDetailsSelector/SavedPaymentDetailsSelector.tsx
@@ -1,12 +1,11 @@
 import { InputGroupLabel } from "../InputGroupLabel/InputGroupLabel";
 import AddIcon from '@mui/icons-material/Add';
 import { StackList } from "../StackList/StackList";
-import { useCallback } from "react";
 import { SecondaryButton } from "../SecondaryButton/SecondaryButton";
 import { PaymentDetailsItem } from "../../payments/PaymentDetailsItem/Item/PaymentDetailsItem";
-import { CheckoutModalFooter } from "../../payments/CheckoutModalFooter/CheckoutModalFooter";
+import { CheckoutModalFooter, ConsentType } from "../../payments/CheckoutModalFooter/CheckoutModalFooter";
 import { SavedPaymentMethod } from "../../../domain/circle/circle.interfaces";
-import React from "react";
+import React, { useCallback } from "react";
 import { Box, CircularProgress } from "@mui/material";
 
 export interface SavedPaymentDetailsSelectorProps {
@@ -18,6 +17,7 @@ export interface SavedPaymentDetailsSelectorProps {
   onPick: (paymentMethodId: string) => void;
   onNext: () => void;
   onClose: () => void;
+  consentType: ConsentType;
   privacyHref: string;
   termsOfUseHref: string;
 }
@@ -31,10 +31,15 @@ export const SavedPaymentDetailsSelector: React.FC<SavedPaymentDetailsSelectorPr
   onPick,
   onNext,
   onClose,
+  consentType,
   privacyHref,
   termsOfUseHref,
 }) => {
   const getPaymentMethodId = useCallback((savedPaymentMethod: SavedPaymentMethod) => savedPaymentMethod.id, []);
+
+  const handleNextClicked = useCallback((canSubmit: boolean) => {
+    if (canSubmit) onNext();
+  }, [onNext]);
 
   return (<>
     <Box sx={{ position: "relative" }}>
@@ -68,7 +73,11 @@ export const SavedPaymentDetailsSelector: React.FC<SavedPaymentDetailsSelectorPr
         itemKey={ getPaymentMethodId }
         deps={[ onDelete, onPick, selectedPaymentMethodId, showLoader]} />
 
-      <SecondaryButton onClick={ onNew } startIcon={ <AddIcon /> } sx={{ mt: 2.5 }} disabled={ showLoader }>
+      <SecondaryButton
+        onClick={ onNew }
+        startIcon={ <AddIcon /> }
+        sx={{ mt: 2.5, mb: consentType === "checkbox" ? 5 : 0 }}
+        disabled={ showLoader }>
         Add New Payment Method
       </SecondaryButton>
 
@@ -76,9 +85,10 @@ export const SavedPaymentDetailsSelector: React.FC<SavedPaymentDetailsSelectorPr
 
     <CheckoutModalFooter
       variant="toConfirmation"
+      consentType={ consentType }
       privacyHref={ privacyHref }
       termsOfUseHref={ termsOfUseHref }
-      onSubmitClicked={ onNext }
+      onSubmitClicked={ handleNextClicked }
       onCloseClicked={ onClose } />
   </>);
 }

--- a/app/src/lib/components/shared/SavedPaymentDetailsSelector/SavedPaymentDetailsSelector.tsx
+++ b/app/src/lib/components/shared/SavedPaymentDetailsSelector/SavedPaymentDetailsSelector.tsx
@@ -3,10 +3,11 @@ import AddIcon from '@mui/icons-material/Add';
 import { StackList } from "../StackList/StackList";
 import { SecondaryButton } from "../SecondaryButton/SecondaryButton";
 import { PaymentDetailsItem } from "../../payments/PaymentDetailsItem/Item/PaymentDetailsItem";
-import { CheckoutModalFooter, ConsentType } from "../../payments/CheckoutModalFooter/CheckoutModalFooter";
+import { CheckoutModalFooter } from "../../payments/CheckoutModalFooter/CheckoutModalFooter";
 import { SavedPaymentMethod } from "../../../domain/circle/circle.interfaces";
 import React, { useCallback } from "react";
 import { Box, CircularProgress } from "@mui/material";
+import { ConsentType } from "../ConsentText/ConsentText";
 
 export interface SavedPaymentDetailsSelectorProps {
   showLoader: boolean;

--- a/app/src/lib/domain/plaid/plaid.utils.ts
+++ b/app/src/lib/domain/plaid/plaid.utils.ts
@@ -82,7 +82,7 @@ export function getPlaidOAuthFlowState(): PlaidOAuthFlowState {
 
   const continueOAuthFlow = !!(url && linkToken && selectedBillingInfo && receivedRedirectUri);
 
-  if (continueOAuthFlow && savedStateUsed) return clearPlaidInfo();
+  if ((continueOAuthFlow && savedStateUsed) || (!continueOAuthFlow && savedPlaidInfo)) return clearPlaidInfo();
 
   return {
     // The URL of the page where we initially opened the modal:

--- a/app/src/lib/forms/BillingInfoForm.tsx
+++ b/app/src/lib/forms/BillingInfoForm.tsx
@@ -120,6 +120,7 @@ export const BillingInfoForm: React.FC<BillingInfoFormProps> = ({
       ...EMPTY_FORM_VALUES,
       ...defaultValues
     },
+    reValidateMode: "onChange",
     resolver: yupResolver(schema)
   });
 
@@ -231,11 +232,7 @@ export const BillingInfoForm: React.FC<BillingInfoFormProps> = ({
 
       <CheckoutModalFooter
         variant="toPayment"
-        privacyHref=""
-        termsOfUseHref=""
-        onSubmitClicked={submitForm}
-        onCloseClicked={onClose}
-      />
+        onCloseClicked={onClose} />
     </form>
   );
 };

--- a/app/src/lib/forms/PaymentMethodForm.tsx
+++ b/app/src/lib/forms/PaymentMethodForm.tsx
@@ -6,7 +6,7 @@ import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
 import BookIcon from "@mui/icons-material/Book";
 import React, { useCallback, useMemo } from "react";
-import { CheckoutModalFooter, ConsentText, ConsentType, CONSENT_ERROR_MESSAGE } from "../components/payments/CheckoutModalFooter/CheckoutModalFooter";
+import { CheckoutModalFooter} from "../components/payments/CheckoutModalFooter/CheckoutModalFooter";
 import { ControlledTextField } from "../components/shared/TextField/TextField";
 import { ControlledCardNumberField } from "../components/shared/CardNumberField";
 import { ControlledCardExpiryDateField } from "../components/shared/CardExpiryDateField";
@@ -30,6 +30,7 @@ import {
 import { Typography } from "@mui/material";
 import { DisplayBox } from "../components/payments/DisplayBox/DisplayBox";
 import { ControlledCheckbox } from "../components/shared/Checkbox";
+import { ConsentText, ConsentType, CONSENT_ERROR_MESSAGE } from "../components/shared/ConsentText/ConsentText";
 
 interface PaymentTypeFormProps {
   control: Control<PaymentMethod & { consent: boolean }>;

--- a/app/src/lib/views/Payment/PaymentView.tsx
+++ b/app/src/lib/views/Payment/PaymentView.tsx
@@ -13,7 +13,7 @@ import { billingInfoToSavedPaymentMethodBillingInfo } from "../../domain/circle/
 import { SelectedPaymentMethod } from "../../components/payments/CheckoutModal/CheckoutModal";
 import { BoxProps, Divider } from "@mui/material";
 import { usePlaid } from "../../hooks/usePlaid";
-import { ConsentType } from "../../components/payments/CheckoutModalFooter/CheckoutModalFooter";
+import { ConsentType } from "../../components/shared/ConsentText/ConsentText";
 
 const billingInfoItemBoxProps: BoxProps = { sx: { mt: 2.5 } };
 

--- a/app/src/lib/views/Payment/PaymentView.tsx
+++ b/app/src/lib/views/Payment/PaymentView.tsx
@@ -11,8 +11,9 @@ import { BillingInfoItem } from "../../components/payments/BillingInfo/Item/Bill
 import { SavedPaymentMethod } from "../../domain/circle/circle.interfaces";
 import { billingInfoToSavedPaymentMethodBillingInfo } from "../../domain/circle/circle.utils";
 import { SelectedPaymentMethod } from "../../components/payments/CheckoutModal/CheckoutModal";
-import { BoxProps } from "@mui/material";
+import { BoxProps, Divider } from "@mui/material";
 import { usePlaid } from "../../hooks/usePlaid";
+import { ConsentType } from "../../components/payments/CheckoutModalFooter/CheckoutModalFooter";
 
 const billingInfoItemBoxProps: BoxProps = { sx: { mt: 2.5 } };
 
@@ -26,6 +27,7 @@ export interface PaymentViewProps {
   onPrev: () => void;
   onClose: () => void;
   acceptedPaymentTypes: PaymentType[];
+  consentType: ConsentType;
   privacyHref: string;
   termsOfUseHref: string;
 }
@@ -40,6 +42,7 @@ export const PaymentView: React.FC<PaymentViewProps> = ({
   onPrev,
   onClose,
   acceptedPaymentTypes,
+  consentType,
   privacyHref,
   termsOfUseHref,
 }) => {
@@ -117,6 +120,8 @@ export const PaymentView: React.FC<PaymentViewProps> = ({
       data={ selectedPaymentMethodBillingInfo }
       additionalProps={{ onEdit: onPrev, disabled: isDeleting, boxProps: billingInfoItemBoxProps }} />
 
+    <Divider sx={{ mt: 2.5 }} />
+
     { showSaved ? (
       <SavedPaymentDetailsSelector
         showLoader={ isDeleting }
@@ -127,6 +132,7 @@ export const PaymentView: React.FC<PaymentViewProps> = ({
         onPick={ onPaymentInfoSelected }
         onNext={ onNext }
         onClose={ onClose }
+        consentType={ consentType }
         privacyHref={ privacyHref }
         termsOfUseHref={ termsOfUseHref } />
     ) : (
@@ -137,6 +143,7 @@ export const PaymentView: React.FC<PaymentViewProps> = ({
         onSaved={ savedPaymentMethods.length > 0 ? handleShowSaved : undefined }
         onClose={ onClose }
         onSubmit={ handleSubmit }
+        consentType={ consentType }
         privacyHref={ privacyHref }
         termsOfUseHref={ termsOfUseHref } />
     ) }

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -171,7 +171,7 @@ const HomePage = () => {
     purchaseInstructions: PLAYGROUND_PURCHASE_INSTRUCTIONS,
 
     // Legal:
-    consentType: "checkbox",
+    consentType: undefined,
     privacyHref: PLAYGROUND_PRIVACY_HREF,
     termsOfUseHref: PLAYGROUND_TERMS_OF_USE_HREF,
 

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -171,7 +171,7 @@ const HomePage = () => {
     purchaseInstructions: PLAYGROUND_PURCHASE_INSTRUCTIONS,
 
     // Legal:
-    consentType: undefined,
+    consentType: "checkbox",
     privacyHref: PLAYGROUND_PRIVACY_HREF,
     termsOfUseHref: PLAYGROUND_TERMS_OF_USE_HREF,
 

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -55,7 +55,7 @@ const HomePage = () => {
   const organizations = isLoading ? [] : (meData?.me?.userOrgs || []).map(userOrg => userOrg.organization);
 
   useEffect(() => {
-    console.log(continuePlaidOAuthFlow() ? "Continue Plaid OAuth Flow" : "New flow.");
+    if (continuePlaidOAuthFlow()) console.log("💾 Continue Plaid OAuth Flow...");
   }, []);
 
   useEffect(() => {
@@ -171,7 +171,7 @@ const HomePage = () => {
     purchaseInstructions: PLAYGROUND_PURCHASE_INSTRUCTIONS,
 
     // Legal:
-    consentType: "disclaimer",
+    consentType: "checkbox",
     privacyHref: PLAYGROUND_PRIVACY_HREF,
     termsOfUseHref: PLAYGROUND_TERMS_OF_USE_HREF,
 


### PR DESCRIPTION
There are now 3 possible configurations for the consent:
- (A) Not show anything.
- (B) Show a disclaimer.
- (C) Show a checkbox that must be checked to be able to purchase.

Also, you can provide a privacy link, a terms of use link or both.

**With saved payment methods:**

- (A)
  ![image](https://user-images.githubusercontent.com/6564894/152893242-3d04e4b5-425d-4395-890b-af2bd337dfdd.png)
- (B)
  ![image](https://user-images.githubusercontent.com/6564894/152893377-b6496307-2d76-496a-9e1e-dfe1088603f1.png)
- (C)
  ![image](https://user-images.githubusercontent.com/6564894/152893545-8f93978f-f784-4102-baac-d8cb0c03213e.png)
- (C) + Error state:
  ![image](https://user-images.githubusercontent.com/6564894/152893675-5fed7ced-1664-4d07-8229-c0fcdfea6503.png)

**With new payment method:**

- (A)
  ![image](https://user-images.githubusercontent.com/6564894/152893768-a181a47b-f969-4c1b-95f5-20717ba5ed41.png)
- (B)
  ![image](https://user-images.githubusercontent.com/6564894/152893862-f330dbcb-0b05-408c-aff1-7407f258ba74.png)
- (C)
  ![image](https://user-images.githubusercontent.com/6564894/152893945-3df014a2-fd17-4a66-8041-3100b823bb24.png)
- (C) + Error state:
  ![image](https://user-images.githubusercontent.com/6564894/152894026-1ba8a252-306b-4035-8c36-7eb0f14a51c3.png)
