### PR TITLE
MOJITO-924: Export AuthorizedApolloProvider.

### DIFF
--- a/app/src/lib/components/shared/AuthorizedApolloProvider/AuthorizedApolloProvider.tsx
+++ b/app/src/lib/components/shared/AuthorizedApolloProvider/AuthorizedApolloProvider.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import {
   ApolloClient,
   ApolloProvider,
@@ -8,10 +8,14 @@ import {
 import { setContext } from "@apollo/client/link/context";
 import { useAuth0 } from "@auth0/auth0-react";
 
-export function AuthorizedApolloProvider({
+export interface AuthorizedApolloProviderProps {
+  uri: string
+}
+
+export const AuthorizedApolloProvider: React.FC<AuthorizedApolloProviderProps> = ({
   uri,
   children,
-}: PropsWithChildren<{ uri: string }>) {
+}) => {
   const { getIdTokenClaims } = useAuth0();
 
   const httpLink = createHttpLink({

--- a/app/src/lib/index.ts
+++ b/app/src/lib/index.ts
@@ -3,6 +3,7 @@ export { MOJITO_LIGHT_THEME, MOJITO_DARK_THEME } from "./config/theme/theme";
 export { ThemeProvider as CheckoutModalThemeProvider } from "@mui/material/styles";
 export { getPlaidOAuthFlowState, persistPlaidReceivedRedirectUri } from "./domain/plaid/plaid.utils";
 export { INITIAL_PLAID_OAUTH_FLOW_STATE, continuePlaidOAuthFlow } from "./hooks/usePlaid";
+export { AuthorizedApolloProvider } from "./components/shared/AuthorizedApolloProvider/AuthorizedApolloProvider";
 
 export type { Theme as CheckoutModalTheme, ThemeOptions as CheckoutModalThemeOptions } from "@mui/material/styles";
 export type { CheckoutModalProps } from "./components/payments/CheckoutModal/CheckoutModal";

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -1,12 +1,12 @@
 import App from "next/app";
 import { Auth0Provider } from "@auth0/auth0-react";
-import { AuthorizedApolloProvider } from "../components/auth/AuthorizedApolloProvider";
 import { GlobalLayout } from "../components/core/GlobalLayout";
 import { config } from "../utils/config/config.constants";
 import { AppProps } from "next/app";
 import { Header } from "../components/core/Header";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import Head from "next/head";
+import { AuthorizedApolloProvider } from "../lib";
 
 const defaultTheme = createTheme();
 


### PR DESCRIPTION
While we want to migrate from Apollo to `react-query`, we need a solution to make it easy to integrate this in projects that are not using Apollo already.

As a temporary solution, we will be exporting `AuthorizedApolloProvider` from this library for consumers to add it if needed (if there are already using Apollo, they might not need it).