### PR TITLE
Include new footer section for CheckoutModalFooter

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,9 +283,21 @@ You will have to copy the following file into your project to avoid TypeScript e
 
 ## Images
 
-The `PurchasingView` and `ErrorView` default images are loaded directly from GitHub to avoid bundling them with the library
+The `PaymentView`, `PurchasingView` and `ErrorView` default images are loaded directly from GitHub to avoid bundling them with the library
 or forcing users to include them in their repos and add the necessary build setup to load them. They should just work out
 of the box, no setup required.
+
+**`PaymentView`'s default image:**
+
+<p>
+  <a href="https://raw.githubusercontent.com/mojitoinc/mojito-mixers/main/app/src/lib/assets/circle.png">
+    <img src="./app/src/lib/assets/circle.png" width="128">
+  </a>
+</p>
+
+    > Repo: https://github.com/mojitoinc/mojito-mixers/blob/main/app/src/lib/assets/circle.png
+
+    > CDN URL: https://raw.githubusercontent.com/mojitoinc/mojito-mixers/main/app/src/lib/assets/circle.png
 
 **`PurchaseView`'s default image:**
 

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -8,8 +8,7 @@ module.exports = withImages({
 
   images: {
     // Do not add due to vulnerability: https://github.com/mojitoinc/mojito-mixers/security/dependabot/6
-    domains: [
-    ],
+    domains: [],
     loader: "imgix",
     path: "/",
   },

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -8,9 +8,10 @@ module.exports = withImages({
 
   images: {
     // Do not add due to vulnerability: https://github.com/mojitoinc/mojito-mixers/security/dependabot/6
-    // domains: [],
+    domains: [
+    ],
     loader: "imgix",
-    path: "/",
+    path: "",
   },
 
   distDir: "build",

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -11,7 +11,7 @@ module.exports = withImages({
     domains: [
     ],
     loader: "imgix",
-    path: "",
+    path: "/",
   },
 
   distDir: "build",

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -8,7 +8,7 @@ module.exports = withImages({
 
   images: {
     // Do not add due to vulnerability: https://github.com/mojitoinc/mojito-mixers/security/dependabot/6
-    domains: [],
+    // domains: [],
     loader: "imgix",
     path: "/",
   },

--- a/app/src/lib/components/payments/CheckoutModalFooter/CheckoutModalFooter.tsx
+++ b/app/src/lib/components/payments/CheckoutModalFooter/CheckoutModalFooter.tsx
@@ -1,11 +1,12 @@
 import { Box, Link, Typography, Divider, CircularProgress } from "@mui/material";
 import React, { useCallback, useState } from "react";
-import { SM_MOBILE_MAX_WIDTH } from "../../../config/theme/theme";
+import { DEFAULT_PAYMENT_IMAGE_SRC, SM_MOBILE_MAX_WIDTH } from "../../../config/theme/theme";
 import { isPromise } from "../../../utils/promiseUtils";
 import { Checkbox } from "../../shared/Checkbox/Checkbox";
 import { ConsentText, ConsentType, CONSENT_ERROR_MESSAGE } from "../../shared/ConsentText/ConsentText";
 import { PrimaryButton } from "../../shared/PrimaryButton/PrimaryButton";
 import { ICONS_BY_VARIANT, LABELS_BY_VARIANT } from "./CheckoutModalFooter.constants";
+import Image from 'next/image'
 
 interface CheckoutModalFooterConsentState {
   isFormSubmitted: boolean;
@@ -40,7 +41,7 @@ export const CheckoutModalFooter: React.FC<CheckoutModalFooterProps> = ({
 }) => {
   // CONSENT:
   const showConsent = consentType && (privacyHref || termsOfUseHref) && (variant === "toConfirmation" || variant === "toPlaid");
-  const consentTextElement = showConsent ? <ConsentText privacyHref={ privacyHref } termsOfUseHref={ termsOfUseHref } /> : null;
+  const consentTextElement = showConsent ? <ConsentText privacyHref={privacyHref} termsOfUseHref={termsOfUseHref} /> : null;
 
   const [{
     isFormSubmitted,
@@ -107,43 +108,54 @@ export const CheckoutModalFooter: React.FC<CheckoutModalFooterProps> = ({
         pb: 5,
       }}>
 
-      { showConsent && consentType === "checkbox" && (
+      {showConsent && consentType === "checkbox" && (
         <Checkbox
-          label={ <>I { consentTextElement }</> }
-          checked={ isConsentChecked }
-          onChange={ handleConsentClicked }
-          error={ showConsentError }
-          helperText={ showConsentError ? CONSENT_ERROR_MESSAGE : undefined }
+          label={<>I {consentTextElement}</>}
+          checked={isConsentChecked}
+          onChange={handleConsentClicked}
+          error={showConsentError}
+          helperText={showConsentError ? CONSENT_ERROR_MESSAGE : undefined}
           sx={{ alignSelf: "flex-start", mb: 5 }} />
-      ) }
+      )}
 
-      { primaryButtonVisible && (
+      {primaryButtonVisible && (
         <PrimaryButton
-          onClick={ onSubmitClicked ? handleSubmitClicked : undefined }
-          type={ onSubmitClicked ? "button" : "submit" }
-          endIcon={ isFormLoading ? <CircularProgress color="inherit" size="1em" /> : (PrimaryButtonIcon && <PrimaryButtonIcon />) }
-          disabled={ submitDisabled || isFormLoading }>
-          { primaryButtonLabel }
+          onClick={onSubmitClicked ? handleSubmitClicked : undefined}
+          type={onSubmitClicked ? "button" : "submit"}
+          endIcon={isFormLoading ? <CircularProgress color="inherit" size="1em" /> : (PrimaryButtonIcon && <PrimaryButtonIcon />)}
+          disabled={submitDisabled || isFormLoading}>
+          {primaryButtonLabel}
         </PrimaryButton>
-      ) }
+      )}
 
-      { variant !== "toMarketplace" && onCloseClicked && (
-        <Typography sx={ primaryButtonVisible ? { pt: 2 } : undefined }>
-          { primaryButtonVisible ? "or " : null }
-          <Link sx={{ color: "text.primary" }} href="" onClick={ handleCancelClicked }>
+      {variant !== "toMarketplace" && onCloseClicked && (
+        <Typography sx={primaryButtonVisible ? { pt: 2 } : undefined}>
+          {primaryButtonVisible ? "or " : null}
+          <Link sx={{ color: "text.primary" }} href="" onClick={handleCancelClicked}>
             Cancel and Return to Marketplace
           </Link>
         </Typography>
-      ) }
+      )}
 
-      { showConsent && consentType === "disclaimer" && (<>
-        <Divider sx={{ my: 5, width: "100%" }}/>
+      {showConsent && consentType === "disclaimer" && (<>
+        <Divider sx={{ my: 5, width: "100%" }} />
 
         <Typography sx={{ maxWidth: SM_MOBILE_MAX_WIDTH }} align="center">
-          By placing an order you affirm that you { consentTextElement }.
+          By placing an order you affirm that you {consentTextElement}.
         </Typography>
-      </>) }
+      </>)}
 
+      {showConsent && consentType === "circle" && (
+        <>
+          <Divider sx={{ my: 5, width: "100%" }} />
+          <Box display="flex">
+            <Typography sx={{ maxWidth: SM_MOBILE_MAX_WIDTH, marginRight: 1 }} align="center">
+              Payments powered by
+            </Typography>
+            <Image width={100} height={20} src={DEFAULT_PAYMENT_IMAGE_SRC} />
+          </Box>
+        </>
+      )}
     </Box>
   );
 }

--- a/app/src/lib/components/payments/CheckoutModalFooter/CheckoutModalFooter.tsx
+++ b/app/src/lib/components/payments/CheckoutModalFooter/CheckoutModalFooter.tsx
@@ -6,7 +6,6 @@ import { Checkbox } from "../../shared/Checkbox/Checkbox";
 import { ConsentText, ConsentType, CONSENT_ERROR_MESSAGE } from "../../shared/ConsentText/ConsentText";
 import { PrimaryButton } from "../../shared/PrimaryButton/PrimaryButton";
 import { ICONS_BY_VARIANT, LABELS_BY_VARIANT } from "./CheckoutModalFooter.constants";
-import Image from 'next/image'
 
 interface CheckoutModalFooterConsentState {
   isFormSubmitted: boolean;

--- a/app/src/lib/components/payments/CheckoutModalFooter/CheckoutModalFooter.tsx
+++ b/app/src/lib/components/payments/CheckoutModalFooter/CheckoutModalFooter.tsx
@@ -152,7 +152,7 @@ export const CheckoutModalFooter: React.FC<CheckoutModalFooterProps> = ({
             <Typography sx={{ maxWidth: SM_MOBILE_MAX_WIDTH, marginRight: 1 }} align="center">
               Payments powered by
             </Typography>
-            <Image width={100} height={20} src={DEFAULT_PAYMENT_IMAGE_SRC} />
+            <Box component="img" src={DEFAULT_PAYMENT_IMAGE_SRC} height={20} />
           </Box>
         </>
       )}

--- a/app/src/lib/components/shared/ConsentText/ConsentText.tsx
+++ b/app/src/lib/components/shared/ConsentText/ConsentText.tsx
@@ -3,7 +3,7 @@ import React, { Fragment } from "react";
 
 export const CONSENT_ERROR_MESSAGE = "You must accept the terms and conditions of the sale.";
 
-export type ConsentType = "disclaimer" | "checkbox";
+export type ConsentType = "disclaimer" | "checkbox" | "circle";
 
 export interface ConsentTextProps {
   privacyHref?: string;

--- a/app/src/lib/config/theme/theme.ts
+++ b/app/src/lib/config/theme/theme.ts
@@ -20,6 +20,7 @@ export const OVERLAY_OPACITY = 0.75;
 
 // Default images:
 export const DEFAULT_PURCHASING_IMAGE_SRC = "https://raw.githubusercontent.com/mojitoinc/mojito-mixers/main/app/src/lib/assets/mojito-loader.gif";
+export const DEFAULT_PAYMENT_IMAGE_SRC = "https://raw.githubusercontent.com/mojitoinc/mojito-mixers/main/app/src/lib/assets/circle.png";
 
 
 const mojitoLightTheme: Theme = createTheme({


### PR DESCRIPTION
Added new `consentType: "circle"` to the `PUICheckout` component in order to show a new footer

<img width="294" alt="image" src="https://user-images.githubusercontent.com/31553757/155988239-6c18a4d9-aba5-4430-9d17-a6924f829dd0.png">
