### PR TITLE
ENTP-603: Adds a RegExp to validate the Full Name characters.

### DIFF
--- a/app/src/lib/forms/BillingInfoForm.tsx
+++ b/app/src/lib/forms/BillingInfoForm.tsx
@@ -13,7 +13,7 @@ import { SecondaryButton } from "../components/shared/SecondaryButton/SecondaryB
 import { Box, InputAdornment, Typography } from "@mui/material";
 import BookIcon from "@mui/icons-material/Book";
 import { EMPTY_OPTION, SelectOption } from "../components/shared/Select/Select";
-import { withFullNameErrorMessage, withPhoneErrorMessage, withRequiredErrorMessage } from "../utils/validationUtils";
+import { withFullNameCharsetErrorMessage, withFullNameErrorMessage, withPhoneErrorMessage, withRequiredErrorMessage } from "../utils/validationUtils";
 import { DebugBox } from "../components/payments/DebugBox/DebugBox";
 import { CheckoutModalError } from "../components/public/CheckoutOverlay/CheckoutOverlay.hooks";
 import { useFormCheckoutError } from "../hooks/useFormCheckoutError";
@@ -82,6 +82,7 @@ const schema = object()
     [FULL_NAME_FIELD]: string()
       .label(FIELD_LABELS[FULL_NAME_FIELD])
       .required(withRequiredErrorMessage)
+      .matches(/^[a-zA-ZÀ-ÿ.·' -]+$/, withFullNameCharsetErrorMessage)
       .test({
         name: "is-valid-full-name",
         test: (value) => {

--- a/app/src/lib/forms/BillingInfoForm.tsx
+++ b/app/src/lib/forms/BillingInfoForm.tsx
@@ -82,7 +82,7 @@ const schema = object()
     [FULL_NAME_FIELD]: string()
       .label(FIELD_LABELS[FULL_NAME_FIELD])
       .required(withRequiredErrorMessage)
-      .matches(/^[a-zA-ZÀ-ÿ.·' -]+$/, withFullNameCharsetErrorMessage)
+      .matches(/^[A-Za-zÀ-ÖØ-öø-ÿ.·' -]+$/, withFullNameCharsetErrorMessage)
       .test({
         name: "is-valid-full-name",
         test: (value) => {

--- a/app/src/lib/utils/validationUtils.ts
+++ b/app/src/lib/utils/validationUtils.ts
@@ -15,6 +15,8 @@ export const withInvalidErrorMessage = ({ label }: { label: string }) => `${ lab
 
 export const withFullNameErrorMessage = ({ label }: { label: string }) => `${ label } must have at least first and last name.`;
 
+export const withFullNameCharsetErrorMessage = ({ label }: { label: string }) => `${ label } contains invalid characters.`;
+
 export const withPhoneErrorMessage = ({ label }: { label: string }) => `${ label } must be a valid phone number.`;
 
 export const withInvalidCardNumber = ({ label }: { label: string }) => `${ label } is invalid.`;


### PR DESCRIPTION
I’m adding the following RegExp: `^[a-zA-ZÀ-ÿ.·' -]+$ , which includes:

- Lower and upper case letters, including Ç (Catalan) and Ñ (Spanish).
- Accentuated characters, including all Spanish ones as well as some other ones such as ý or ÿ.
- Dot (.), middle-dot (·) and quote ('), used in Catalan.
- Space.
- Dash.
- Includes æ and Æ but not its accentuated variants: https://en.wikipedia.org/wiki/%C3%86

Sorry, X Æ A-12…  