### PR TITLE
ENTP-504: Adds a CheckoutOverlayProvider to instantiate the Payment UI only once across a whole app and do it ASAP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ const App: React.FC = () => {
     open: isOpen,
     onClose,
     onGoTo: handleGoToClicked,
-    onGoToLabel: "View Invoices",
+    goToHref: "/profile/invoices",
+    goToLabel: "View Invoices",
 
     // Flow:
     loaderMode,

--- a/app/src/lib/components/payments/CheckoutModalFooter/CheckoutModalFooter.tsx
+++ b/app/src/lib/components/payments/CheckoutModalFooter/CheckoutModalFooter.tsx
@@ -34,6 +34,7 @@ export interface CheckoutModalFooterProps {
   onCloseClicked?: () => void;
 
   // Collection button:
+  goToHref?: string;
   goToLabel?: string;
   onGoTo?: () => void;
 }
@@ -58,6 +59,7 @@ export const CheckoutModalFooter: React.FC<CheckoutModalFooterProps> = ({
   onCloseClicked,
 
   // Secondary button:
+  goToHref = "/profile/invoices",
   goToLabel = "View Invoices",
   onGoTo,
 }) => {
@@ -169,7 +171,7 @@ export const CheckoutModalFooter: React.FC<CheckoutModalFooterProps> = ({
         <PrimaryButton
           onClickCapture={ handleGoToClicked }
           disabled={ isPrimaryButtonDisabled }
-          href="/profile/invoices"
+          href={ goToHref }
           sx={{ mb: 2 }}>
           { goToLabel }
         </PrimaryButton>

--- a/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.tsx
+++ b/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.tsx
@@ -43,6 +43,7 @@ export interface PUICheckoutOverlayProps {
   open: boolean;
   onClose: () => void;
   onGoTo?: () => void;
+  goToHref?: string;
   goToLabel?: string;
 
   // Flow:
@@ -98,6 +99,8 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
   open,
   onClose,
   onGoTo,
+  // TODO: Move to dictionary:
+  goToHref,
   goToLabel,
 
   // Flow:
@@ -836,6 +839,7 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
         circlePaymentID={ circlePaymentID }
         wallet={ wallet }
         onNext={ handleClose }
+        goToHref={ goToHref }
         goToLabel={ goToLabel }
         onGoTo={ onGoTo } />
     );

--- a/app/src/lib/views/Confirmation/ConfirmationView.tsx
+++ b/app/src/lib/views/Confirmation/ConfirmationView.tsx
@@ -17,6 +17,7 @@ export interface ConfirmationViewProps {
   circlePaymentID: string;
   wallet: null | string | Wallet;
   onNext: () => void;
+  goToHref?: string;
   goToLabel?: string;
   onGoTo?: () => void;
 }
@@ -28,6 +29,7 @@ export const ConfirmationView: React.FC<ConfirmationViewProps> = ({
   circlePaymentID,
   wallet,
   onNext,
+  goToHref,
   goToLabel,
   onGoTo,
 }) => {
@@ -83,6 +85,7 @@ export const ConfirmationView: React.FC<ConfirmationViewProps> = ({
         <CheckoutModalFooter
           variant="toMarketplace"
           onSubmitClicked={onNext}
+          goToHref={goToHref}
           goToLabel={goToLabel}
           onGoTo={onGoTo} />
       </Stack>


### PR DESCRIPTION
This fixes/removes the flickering when being redirected to/from 3DS in frontend setups where the Payment UI or even the page that has to show it are not rendered in the initial page load.