### PR TITLE
ENTP-504: Adds a CheckoutOverlayProvider to instantiate the Payment UI only once across a whole app and do it ASAP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ const App: React.FC = () => {
     open: isOpen,
     onClose,
     onGoTo: handleGoToClicked,
-    onGoToLabel: "View Invoices",
+    goToHref: "/profile/invoices",
+    goToLabel: "View Invoices",
 
     // Flow:
     loaderMode,

--- a/README.md
+++ b/README.md
@@ -273,7 +273,6 @@ const App: React.FC = () => {
     onEvent: handleEvent,
     onError: handleError,
     onCatch: handleCatch,
-    onMarketingOptInChange: handleMarketingOptInChange,
   };
 
   return <PUICheckout { ...checkoutModalProps } />;

--- a/app/src/components/checkout-component/CheckoutComponent.tsx
+++ b/app/src/components/checkout-component/CheckoutComponent.tsx
@@ -6,7 +6,7 @@ import { PUICheckout, PUICheckoutProps } from "../../lib/components/public/Check
 import { CheckoutComponentWithRequiredProps } from "../../lib/components/public/CheckoutOverlayProvider/CheckoutOverlayProvider";
 import { isLocalhost } from "../../lib/domain/url/url.utils";
 import { config } from "../../utils/config/config.constants";
-import { PLAYGROUND_MOJITO_LOGO } from "../../utils/playground/playground.constants";
+import { PLAYGROUND_MOJITO_LOGO, PLAYGROUND_USER_FORMAT } from "../../utils/playground/playground.constants";
 
 export const CheckoutComponent: React.FC<CheckoutComponentWithRequiredProps> = (checkoutComponentProps) => {
   const router = useRouter();
@@ -96,7 +96,7 @@ export const CheckoutComponent: React.FC<CheckoutComponentWithRequiredProps> = (
     // purchasingMessages,
     // successImageSrc,
     // errorImageSrc,
-    // userFormat,
+    userFormat: PLAYGROUND_USER_FORMAT,
     // acceptedPaymentTypes,
     // acceptedCreditCardNetworks,
     // network,

--- a/app/src/components/checkout-component/CheckoutComponent.tsx
+++ b/app/src/components/checkout-component/CheckoutComponent.tsx
@@ -1,0 +1,130 @@
+import { useAuth0 } from "@auth0/auth0-react";
+import { useRouter } from "next/router";
+import React, { ErrorInfo, useCallback } from "react";
+import { CheckoutEventData, CheckoutEventType, CheckoutModalError, MOJITO_LIGHT_THEME } from "../../lib";
+import { PUICheckout, PUICheckoutProps } from "../../lib/components/public/CheckoutOverlay/CheckoutOverlay";
+import { CheckoutComponentWithRequiredProps } from "../../lib/components/public/CheckoutOverlayProvider/CheckoutOverlayProvider";
+import { isLocalhost } from "../../lib/domain/url/url.utils";
+import { config } from "../../utils/config/config.constants";
+import { PLAYGROUND_MOJITO_LOGO } from "../../utils/playground/playground.constants";
+
+export const CheckoutComponent: React.FC<CheckoutComponentWithRequiredProps> = (checkoutComponentProps) => {
+  const router = useRouter();
+
+  const { loginWithPopup, isAuthenticated, isLoading: isAuthenticatedLoading, getIdTokenClaims } = useAuth0();
+
+  const handleGoToClicked = useCallback(() => {
+    router.push("/profile/invoices");
+  }, [router]);
+
+  const onRemoveUrlParams = useCallback((cleanURL: string) => {
+    router.replace(cleanURL, undefined, { shallow: true });
+  }, [router]);
+
+  const handleLogin = useCallback(async () => {
+    await loginWithPopup({ prompt: "login" });
+
+    const token = await getIdTokenClaims();
+
+    console.log({ token });
+  }, [loginWithPopup, getIdTokenClaims]);
+
+  const handleEvent = useCallback((eventType: CheckoutEventType, eventData: CheckoutEventData) => {
+    if (!isLocalhost()) console.log(`🎯 ${ eventType }`, eventData);
+
+    // console.log(`🎯 ${ eventType }`, eventData);
+  }, []);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const handleError = useCallback((error: CheckoutModalError) => {
+    // console.log(error);
+  }, []);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const handleCatch = useCallback((error: Error, errorInfo?: ErrorInfo): void | true => {
+    // console.log(error, errorInfo);
+    // return true;
+  }, []);
+
+  const checkoutProps: PUICheckoutProps = {
+    ...checkoutComponentProps,
+
+    // ProviderInjector:
+    uri: `${config.API_HOSTNAME}/query`,
+
+    // Modal:
+    // open,
+    // onClose,
+    onGoTo: handleGoToClicked,
+
+    // Flow:
+    // loaderMode,
+    // paymentErrorParam,
+    onRemoveUrlParams,
+    guestCheckoutEnabled: false,
+    productConfirmationEnabled: false,
+    // vertexEnabled,
+    // threeDSEnabled,
+
+    // Personalization:
+    theme: MOJITO_LIGHT_THEME,
+
+    /*
+    themeOptions: {
+      // Reference App (https://github.com/mojitoinc/mojito-reference-app/) palette:
+      palette: {
+        primary: {
+          // main: "#FF00FF", // Magenta
+          // contrastText: "#FFFFFF",
+        },
+
+        paymentUI: {
+          // progressBar: "", // Use primary as fallback.
+          // paymentMethodSelectorBorder: "", // Use primary as fallback.
+          // paymentMethodSelectorBackground: "", // Use primary as fallback.
+          // mainButtonBackground: "", // Use primary as fallback.
+          // mainButtonBorderWidth: 0,
+        },
+      },
+    },
+    */
+
+    logoSrc: PLAYGROUND_MOJITO_LOGO,
+    // logoSx,
+    // loaderImageSrc,
+    // purchasingImageSrc,
+    // purchasingMessages,
+    // successImageSrc,
+    // errorImageSrc,
+    // userFormat,
+    // acceptedPaymentTypes,
+    // acceptedCreditCardNetworks,
+    // network,
+
+    dictionary: {
+      privacyHref: "https://mojito.xyz",
+      termsOfUseHref: "https://mojito.xyz",
+    },
+
+    // Legal:
+    consentType: "circle",
+
+    // Data:
+    orgID: checkoutComponentProps.orgID || "",
+    // invoiceID,
+    checkoutItems: checkoutComponentProps.checkoutItems || [],
+
+    // Authentication:
+    onLogin: handleLogin,
+    isAuthenticated,
+    isAuthenticatedLoading,
+
+    // Other Events:
+    debug: true,
+    onEvent: handleEvent,
+    onError: handleError,
+    onCatch: handleCatch,
+  };
+
+  return <PUICheckout {...checkoutProps} />;
+}

--- a/app/src/lib/components/payments/CheckoutModalFooter/CheckoutModalFooter.tsx
+++ b/app/src/lib/components/payments/CheckoutModalFooter/CheckoutModalFooter.tsx
@@ -34,6 +34,7 @@ export interface CheckoutModalFooterProps {
   onCloseClicked?: () => void;
 
   // Collection button:
+  goToHref?: string;
   goToLabel?: string;
   onGoTo?: () => void;
 }
@@ -58,6 +59,7 @@ export const CheckoutModalFooter: React.FC<CheckoutModalFooterProps> = ({
   onCloseClicked,
 
   // Secondary button:
+  goToHref = "/profile/invoices",
   goToLabel = "View Invoices",
   onGoTo,
 }) => {
@@ -169,7 +171,7 @@ export const CheckoutModalFooter: React.FC<CheckoutModalFooterProps> = ({
         <PrimaryButton
           onClickCapture={ handleGoToClicked }
           disabled={ isPrimaryButtonDisabled }
-          href="/profile/invoices"
+          href={ goToHref }
           sx={{ mb: 2 }}>
           { goToLabel }
         </PrimaryButton>

--- a/app/src/lib/components/payments/CheckoutModalHeader/CheckoutModalHeader.tsx
+++ b/app/src/lib/components/payments/CheckoutModalHeader/CheckoutModalHeader.tsx
@@ -36,7 +36,7 @@ export interface CheckoutModalHeaderProps {
   variant: CheckoutModalHeaderVariant;
   countdownElementRef?: React.RefObject<HTMLSpanElement>;
   title?: string;
-  logoSrc: string;
+  logoSrc?: string;
   logoSx?: SxProps<Theme>;
   user?: User;
   userFormat?: UserFormat;
@@ -104,14 +104,16 @@ export const CheckoutModalHeader: React.FC<CheckoutModalHeaderProps> = ({
       <Stack spacing={ 2 } direction="row" sx={{ justifyContent: "space-between", alignItems: "center", py: 2 }}>
         <Typography variant="h5" id="checkout-modal-header-title">{ title }</Typography>
 
-        <Img
-          src={ logoSrc }
-          onClick={ toggleDebug ? handleLogoClick : undefined }
-          sx={{
-            maxHeight: "32px",
-            maxWidth: { xs: "180px", sm: "240px" },
-            ...logoSx
-          }} />
+        { logoSrc && (
+          <Img
+            src={ logoSrc }
+            onClick={ toggleDebug ? handleLogoClick : undefined }
+            sx={{
+              maxHeight: "32px",
+              maxWidth: { xs: "180px", sm: "240px" },
+              ...logoSx
+            }} />
+        ) }
       </Stack>
 
       <Divider />

--- a/app/src/lib/components/payments/SavedItem/SavedItem.tsx
+++ b/app/src/lib/components/payments/SavedItem/SavedItem.tsx
@@ -88,7 +88,7 @@ export const SavedItem: React.FC<SavedItemProps> = ({
       pick: onPick,
     }[action];
 
-    if (callback && id !== undefined) callback(id, e);
+    if (callback) callback(id || "", e);
   }, [id, onEdit, onDelete, onPick]);
 
   const disabledSelect = !!disabled;

--- a/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.tsx
+++ b/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.tsx
@@ -493,9 +493,9 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
   const [deletePaymentMethod] = useDeletePaymentMethodMutation();
 
   const handleSavedPaymentMethodDeleted = useCallback(async (addressIdOrPaymentMethodId: string) => {
-    const idsToDelete: string[] = checkoutStep === "billing"
+    const idsToDelete: string[] = (checkoutStep === "billing"
       ? savedPaymentMethods.filter(({ addressId }) => addressId === addressIdOrPaymentMethodId).map(({ id }) => id)
-      : [addressIdOrPaymentMethodId];
+      : [addressIdOrPaymentMethodId]).filter(Boolean);
 
     if (idsToDelete.length === 0) return;
 

--- a/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.tsx
+++ b/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.tsx
@@ -43,6 +43,7 @@ export interface PUICheckoutOverlayProps {
   open: boolean;
   onClose: () => void;
   onGoTo?: () => void;
+  goToHref?: string;
   goToLabel?: string;
 
   // Flow:
@@ -98,6 +99,8 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
   open,
   onClose,
   onGoTo,
+  // TODO: Move to dictionary:
+  goToHref,
   goToLabel,
 
   // Flow:
@@ -836,6 +839,7 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
         circlePaymentID={ circlePaymentID }
         wallet={ wallet }
         onNext={ handleClose }
+        goToHref={ goToHref }
         goToLabel={ goToLabel }
         onGoTo={ onGoTo } />
     );

--- a/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.tsx
+++ b/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.tsx
@@ -56,15 +56,15 @@ export interface PUICheckoutOverlayProps {
   threeDSEnabled?: boolean;
 
   // Personalization:
-  logoSrc: string;
+  logoSrc?: string;
   logoSx?: SxProps<Theme>;
-  loaderImageSrc: string;
-  purchasingImageSrc: string;
+  loaderImageSrc?: string;
+  purchasingImageSrc?: string;
   purchasingMessages?: false | string[];
-  successImageSrc: string;
-  errorImageSrc: string;
-  userFormat: UserFormat;
-  acceptedPaymentTypes: PaymentType[];
+  successImageSrc?: string;
+  errorImageSrc?: string;
+  userFormat?: UserFormat;
+  acceptedPaymentTypes?: PaymentType[];
   acceptedCreditCardNetworks?: CreditCardNetwork[];
   network?: Network;
   paymentLimits?: Partial<Record<PaymentType, number>>;
@@ -87,7 +87,6 @@ export interface PUICheckoutOverlayProps {
   debug?: boolean;
   onEvent?: (eventType: CheckoutEventType, eventData: CheckoutEventData) => void;
   onError?: (error: CheckoutModalError) => void;
-  onMarketingOptInChange?: (marketingOptIn: boolean) => void;
 }
 
 export type PUICheckoutProps = PUICheckoutOverlayProps & ProvidersInjectorProps;
@@ -144,7 +143,6 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
   debug: parentDebug,
   onEvent,
   onError,
-  onMarketingOptInChange, // Not implemented yet. Used to let user subscribe / unsubscribe to marketing updates.
 }) => {
   const [debug, setDebug] = useState(!!parentDebug);
 
@@ -201,7 +199,7 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
     error: paymentMethodsError,
     refetch: refetchPaymentMethods,
   } = useGetPaymentMethodListQuery({
-    skip: !isAuthenticated,
+    skip: !isAuthenticated || !orgID,
     variables: { orgID },
   });
 
@@ -259,7 +257,7 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
 
   // Modal loading state:
 
-  const isDialogLoading = isAuthenticatedLoading || meLoading || paymentMethodsLoading;
+  const isDialogLoading = !orgID || parentCheckoutItems.length === 0 || isAuthenticatedLoading || meLoading || paymentMethodsLoading;
   const isDialogInitializing = isDialogLoading || invoiceDetailsLoading || !invoiceID;
   const isPlaidFlowLoading = continuePlaidOAuthFlow();
   const [loaderMode, setLoaderMode] = useState(initialLoaderMode);

--- a/app/src/lib/components/public/CheckoutOverlayProvider/CheckoutOverlayProvider.tsx
+++ b/app/src/lib/components/public/CheckoutOverlayProvider/CheckoutOverlayProvider.tsx
@@ -1,0 +1,73 @@
+import React, { createContext, useCallback, useContext, useState } from "react";
+import { PUICheckoutProps } from "../CheckoutOverlay/CheckoutOverlay";
+import { useOpenCloseCheckoutModal, UseOpenCloseCheckoutModalOptions } from "../useOpenCloseCheckoutModal/useOpenCloseCheckoutModal";
+
+export type CheckoutComponentProps = Partial<Omit<
+  PUICheckoutProps,
+  "open" | "onClose" | "loaderMode" | "paymentErrorParam"
+>>;
+
+export type CheckoutComponentWithRequiredProps = Partial<PUICheckoutProps> & Pick<
+  PUICheckoutProps,
+  "open" | "onClose" | "loaderMode" | "paymentErrorParam"
+>;
+
+export interface CheckoutOverlayContextProps {
+  open: (checkoutComponentProps?: CheckoutComponentProps) => void;
+  close: () => void;
+  setCheckoutComponentProps: React.Dispatch<React.SetStateAction<CheckoutComponentProps>>;
+}
+
+export const CheckoutOverlayContext = createContext<CheckoutOverlayContextProps>({
+  open: () => { /* Do nothing */ },
+  close: () => { /* Do nothing */ },
+  setCheckoutComponentProps: () => { /* Do nothing */ },
+});
+
+export interface CheckoutOverlayProviderProps extends UseOpenCloseCheckoutModalOptions {
+  checkoutComponent: React.ComponentType<CheckoutComponentWithRequiredProps>;
+}
+
+export const CheckoutOverlayProvider: React.FC<CheckoutOverlayProviderProps> = ({
+  paymentIdParam,
+  paymentErrorParam,
+  checkoutComponent: CheckoutComponent,
+  children,
+}) => {
+  const { loaderMode, isOpen, onOpen, onClose } = useOpenCloseCheckoutModal({ paymentIdParam, paymentErrorParam });
+
+  const [checkoutComponentProps, setCheckoutComponentProps] = useState<CheckoutComponentProps>({ });
+
+  const handleOnClose = useCallback(() => {
+    onClose();
+
+    // setCheckoutComponentProps({});
+  }, [onClose]);
+
+  const open = useCallback((nextCheckoutComponentProps?: CheckoutComponentProps) => {
+    if (nextCheckoutComponentProps) setCheckoutComponentProps(nextCheckoutComponentProps);
+
+    onOpen();
+  }, [onOpen]);
+
+  const close = useCallback(() => {
+    handleOnClose();
+  }, [handleOnClose]);
+
+  return (
+    <CheckoutOverlayContext.Provider value={ { open, close, setCheckoutComponentProps } }>
+      { children }
+
+      <CheckoutComponent
+        { ...checkoutComponentProps }
+        open={ isOpen }
+        onClose={ handleOnClose }
+        loaderMode={ loaderMode }
+        paymentErrorParam={ paymentErrorParam } />
+    </CheckoutOverlayContext.Provider>
+  );
+}
+
+export function useCheckoutOverlay() {
+  return useContext(CheckoutOverlayContext);
+}

--- a/app/src/lib/components/public/ErrorOverlay/StaticErrorOverlay.tsx
+++ b/app/src/lib/components/public/ErrorOverlay/StaticErrorOverlay.tsx
@@ -14,12 +14,12 @@ export const PUIStaticErrorOverlay: React.FC<PUIStaticErrorOverlayProps> = ({
   logoSx,
   ...errorViewProps
 }) => {
-  const headerElement = logoSrc ? (
+  const headerElement = (
     <CheckoutModalHeader
       variant="error"
       logoSrc={ logoSrc }
       logoSx={ logoSx } />
-  ) : null;
+  );
 
   return (
     <FullScreenOverlay isDialogBlocked centered header={ headerElement }>

--- a/app/src/lib/components/public/SuccessOverlay/StaticSuccessOverlay.tsx
+++ b/app/src/lib/components/public/SuccessOverlay/StaticSuccessOverlay.tsx
@@ -14,12 +14,12 @@ export const PUIStaticSuccessOverlay: React.FC<PUIStaticSuccessOverlayProps> = (
   logoSx,
   ...successViewProps
 }) => {
-  const headerElement = logoSrc ? (
+  const headerElement = (
     <CheckoutModalHeader
       variant="purchasing"
       logoSrc={ logoSrc }
       logoSx={ logoSx } />
-  ) : null;
+  );
 
   return (
     <FullScreenOverlay isDialogBlocked centered header={ headerElement }>

--- a/app/src/lib/forms/PaymentMethodForm.tsx
+++ b/app/src/lib/forms/PaymentMethodForm.tsx
@@ -396,7 +396,7 @@ export const PaymentMethodForm: React.FC<PaymentMethodFormProps> = ({
         </Box>
       )}
 
-      { acceptedPaymentTypes.length > 1 ? (<>
+      { acceptedPaymentTypes.length > 1 && (<>
         <InputGroupLabel sx={{ m: 0, pt: 2, pb: 1.5 }}>Payment Method</InputGroupLabel>
 
         <PaymentMethodSelector
@@ -404,8 +404,10 @@ export const PaymentMethodForm: React.FC<PaymentMethodFormProps> = ({
           onPaymentMethodChange={handleSelectedPaymentMethodChange}
           paymentMethods={acceptedPaymentTypes}
         />
-      </>) : (
-        null
+      </>) }
+
+      { !onSaved && acceptedPaymentTypes.length <= 1 && (
+        <Box sx={{ mt: 1 }} />
       ) }
 
       <Fields

--- a/app/src/lib/hooks/useCheckoutItemCostTotal.ts
+++ b/app/src/lib/hooks/useCheckoutItemCostTotal.ts
@@ -23,6 +23,6 @@ export const useCheckoutItemsCostTotal = (checkoutItems: CheckoutItem[]): UseChe
       return result;
     }, to<UseCheckoutItemsCostTotalReduceResult>({ total: 0, fees: 0, taxAmount: 0 }));
 
-    return { ...reduceResult, taxRate: 100 * reduceResult.taxAmount / reduceResult.total };
+    return { ...reduceResult, taxRate: 100 * reduceResult.taxAmount / (reduceResult.total || 1) };
   }, [checkoutItems]);
 };

--- a/app/src/lib/index.ts
+++ b/app/src/lib/index.ts
@@ -3,7 +3,6 @@ export { PUICheckout } from "./components/public/CheckoutOverlay/CheckoutOverlay
 export { PUISuccess } from "./components/public/SuccessOverlay/SuccessOverlay";
 export { PUIError } from "./components/public/ErrorOverlay/ErrorOverlay";
 export { PUIPlaid } from "./components/public/PlaidOverlay/PlaidOverlay";
-export { useOpenCloseCheckoutModal } from "./components/public/useOpenCloseCheckoutModal/useOpenCloseCheckoutModal";
 export { getPlaidOAuthFlowState, persistPlaidReceivedRedirectUri } from "./domain/plaid/plaid.utils";
 export { continuePlaidOAuthFlow } from "./hooks/usePlaid";
 export { continueCheckout, continueFlows, getCheckoutModalState, persistReceivedRedirectUri3DS } from "./components/public/CheckoutOverlay/CheckoutOverlay.utils";

--- a/app/src/lib/index.ts
+++ b/app/src/lib/index.ts
@@ -9,6 +9,7 @@ export { continuePlaidOAuthFlow } from "./hooks/usePlaid";
 export { continueCheckout, continueFlows, getCheckoutModalState, persistReceivedRedirectUri3DS } from "./components/public/CheckoutOverlay/CheckoutOverlay.utils";
 export { extendDefaultTheme, MOJITO_LIGHT_THEME, MOJITO_DARK_THEME } from "./config/theme/theme";
 export { THREEDS_FLOW_SEARCH_PARAM_SUCCESS_KEY, THREEDS_FLOW_SEARCH_PARAM_ERROR_KEY } from "./config/config";
+export { CheckoutOverlayProvider, useCheckoutOverlay } from "./components/public/CheckoutOverlayProvider/CheckoutOverlayProvider";
 
 export type { Theme as CheckoutModalTheme, ThemeOptions as CheckoutModalThemeOptions } from "@mui/material/styles";
 export type { PUICheckoutProps } from "./components/public/CheckoutOverlay/CheckoutOverlay";
@@ -22,6 +23,7 @@ export type { CircleFieldErrorAt, CircleFieldErrors } from "./domain/circle/circ
 export type { PUIDictionary, PUIDictionaryKeys, PUIDictionarySingleLine, PUIDictionaryMultiLine } from "./domain/dictionary/dictionary.interfaces";
 export type { CheckoutEventType, CheckoutEventData } from "./domain/events/events.interfaces";
 export type { PalettePaymentUI } from "./domain/mui/mui.interfaces";
+export type { CheckoutComponentProps, CheckoutOverlayContextProps, CheckoutOverlayProviderProps } from "./components/public/CheckoutOverlayProvider/CheckoutOverlayProvider";
 
 if (process.env.NODE_ENV === "development" && process.browser) {
   console.log("\n👨‍💻 PUI development mode.\n\n");

--- a/app/src/lib/views/Confirmation/ConfirmationView.tsx
+++ b/app/src/lib/views/Confirmation/ConfirmationView.tsx
@@ -17,6 +17,7 @@ export interface ConfirmationViewProps {
   circlePaymentID: string;
   wallet: null | string | Wallet;
   onNext: () => void;
+  goToHref?: string;
   goToLabel?: string;
   onGoTo?: () => void;
 }
@@ -28,6 +29,7 @@ export const ConfirmationView: React.FC<ConfirmationViewProps> = ({
   circlePaymentID,
   wallet,
   onNext,
+  goToHref,
   goToLabel,
   onGoTo,
 }) => {
@@ -83,6 +85,7 @@ export const ConfirmationView: React.FC<ConfirmationViewProps> = ({
         <CheckoutModalFooter
           variant="toMarketplace"
           onSubmitClicked={onNext}
+          goToHref={goToHref}
           goToLabel={goToLabel}
           onGoTo={onGoTo} />
       </Stack>

--- a/app/src/lib/views/Payment/PaymentView.tsx
+++ b/app/src/lib/views/Payment/PaymentView.tsx
@@ -41,7 +41,7 @@ export interface PaymentViewProps {
   onNext: () => void;
   onPrev: () => void;
   onClose: () => void;
-  acceptedPaymentTypes: PaymentType[];
+  acceptedPaymentTypes?: PaymentType[];
   acceptedCreditCardNetworks?: CreditCardNetwork[];
   consentType?: ConsentType;
   debug?: boolean;
@@ -62,7 +62,7 @@ export const PaymentView: React.FC<PaymentViewProps> = ({
   onNext,
   onPrev,
   onClose,
-  acceptedPaymentTypes,
+  acceptedPaymentTypes = ["CreditCard"],
   acceptedCreditCardNetworks,
   consentType,
   debug,
@@ -128,8 +128,6 @@ export const PaymentView: React.FC<PaymentViewProps> = ({
       onPaymentInfoSelected(lastActiveSavedPaymentMethod.id);
     }
   }, [showSaved, onPaymentInfoSelected, savedPaymentMethods, selectedPaymentInfo/*, checkoutError*/]);
-
-  console.log("selectedPaymentInfo =", selectedPaymentInfo);
 
   // PLAIN LINKS:
   const onPlaidLinkClicked = usePlaid({

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -9,10 +9,18 @@ import { AuthorizedApolloProvider } from "../lib/components/shared/AuthorizedApo
 import { GlobalStyles } from "@mui/material";
 import { GLOBAL_STYLES } from "../components/core/global-styles.constants";
 import { Container } from "../components/core/Container";
+import { CheckoutOverlayProvider } from "../lib/components/public/CheckoutOverlayProvider/CheckoutOverlayProvider";
+import { CheckoutComponent } from "../components/checkout-component/CheckoutComponent";
+import { THREEDS_FLOW_SEARCH_PARAM_SUCCESS_KEY, THREEDS_FLOW_SEARCH_PARAM_ERROR_KEY } from "../lib";
+import { useRouter } from "next/router";
 
 const defaultTheme = createTheme();
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+  const paymentIdParam = router.query[THREEDS_FLOW_SEARCH_PARAM_SUCCESS_KEY]?.toString();
+  const paymentErrorParam = router.query[THREEDS_FLOW_SEARCH_PARAM_ERROR_KEY]?.toString();
+
   return (
     <Auth0Provider
       domain={ config.AUTH0_DOMAIN }
@@ -29,10 +37,17 @@ function MyApp({ Component, pageProps }: AppProps) {
         <ThemeProvider theme={ defaultTheme }>
           <GlobalStyles styles={ GLOBAL_STYLES } />
 
-          <Container>
-            <Header />
-            <Component { ...pageProps } />
-          </Container>
+          <CheckoutOverlayProvider
+            paymentIdParam={ paymentIdParam }
+            paymentErrorParam={ paymentErrorParam }
+            checkoutComponent={ CheckoutComponent }>
+
+            <Container>
+              <Header />
+              <Component { ...pageProps } />
+            </Container>
+
+          </CheckoutOverlayProvider>
 
         </ThemeProvider>
       </AuthorizedApolloProvider>

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { Typography, Box, Stack, Button, FormControl, FormLabel, RadioGroup, For
 import { useCallback, useEffect, useRef, useState } from "react";
 import { PaymentType, CheckoutComponentProps, useCheckoutOverlay } from "../lib";
 import { useMeQuery } from "../services/graphql/generated";
-import { PLAYGROUND_PARAGRAPHS_ARRAY, PLAYGROUND_USER_FORMAT, PLAYGROUND_MOCKED_AUCTION_LOT, PLAYGROUND_MOCKED_BUY_NOW_LOT } from "../utils/playground/playground.constants";
+import { PLAYGROUND_PARAGRAPHS_ARRAY, PLAYGROUND_MOCKED_AUCTION_LOT, PLAYGROUND_MOCKED_BUY_NOW_LOT } from "../utils/playground/playground.constants";
 import { PlaygroundFormData } from "../utils/playground/playground.interfaces";
 
 const DEFAULT_FORM_VALUES: PlaygroundFormData = {
@@ -64,7 +64,6 @@ const HomePage: React.FC = () => {
 
     return {
       // Personalization:
-      userFormat: PLAYGROUND_USER_FORMAT,
       acceptedPaymentTypes: [
         formValues.paymentCC ? "CreditCard" : "",
         formValues.paymentACH ? "ACH" : "",

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -1,15 +1,10 @@
 import { useAuth0 } from "@auth0/auth0-react";
-import { Typography, Box, Stack, Button, FormControl, FormLabel, RadioGroup, FormControlLabel, Radio, FormHelperText, TextField, Switch, Select, MenuItem, InputLabel, FormGroup, Checkbox, SelectChangeEvent } from "@mui/material";
-import { ErrorInfo, useCallback, useEffect, useRef, useState } from "react";
-import { PUICheckout, CheckoutModalError, PUICheckoutProps, PaymentType, useOpenCloseCheckoutModal } from "../lib";
+import { Typography, Box, Stack, Button, FormControl, FormLabel, RadioGroup, FormControlLabel, Radio, TextField, Select, MenuItem, InputLabel, FormGroup, Checkbox, SelectChangeEvent } from "@mui/material";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { PaymentType, CheckoutComponentProps, useCheckoutOverlay } from "../lib";
 import { useMeQuery } from "../services/graphql/generated";
-import { PLAYGROUND_PARAGRAPHS_ARRAY, PLAYGROUND_AUTH_PRESET, PLAYGROUND_NO_AUTH_PRESET, PLAYGROUND_USER_FORMAT, PLAYGROUND_PURCHASING_IMAGE_SRC, PLAYGROUND_ERROR_IMAGE_SRC, PLAYGROUND_LOGOS_SRC, PLAYGROUND_LOGOS_SX, PLAYGROUND_LOADER_IMAGE_SRC, PLAYGROUND_MOCKED_AUCTION_LOT, PLAYGROUND_MOCKED_BUY_NOW_LOT, PLAYGROUND_PRIVACY_HREF, PLAYGROUND_TERMS_OF_USE_HREF, PLAYGROUND_THEMES } from "../utils/playground/playground.constants";
+import { PLAYGROUND_PARAGRAPHS_ARRAY, PLAYGROUND_USER_FORMAT, PLAYGROUND_MOCKED_AUCTION_LOT, PLAYGROUND_MOCKED_BUY_NOW_LOT } from "../utils/playground/playground.constants";
 import { PlaygroundFormData } from "../utils/playground/playground.interfaces";
-import { config } from "../utils/config/config.constants";
-import { CheckoutEventData, CheckoutEventType } from "../lib/domain/events/events.interfaces";
-import { isLocalhost } from "../lib/domain/url/url.utils";
-import { useRouter } from "next/router";
-import { THREEDS_FLOW_SEARCH_PARAM_ERROR_KEY, THREEDS_FLOW_SEARCH_PARAM_SUCCESS_KEY } from "../lib/config/config";
 
 const DEFAULT_FORM_VALUES: PlaygroundFormData = {
   // Organization:
@@ -23,12 +18,6 @@ const DEFAULT_FORM_VALUES: PlaygroundFormData = {
   lotID: "",
   lotType: "buyNow",
   lotUnits: 1,
-
-  // Personalization:
-  theme: "light",
-  customImages: false,
-  notAuthPreset: "noAuthGuestDisabled",
-  authPresets: "authConfirmationDisabled",
 
   // Payment:
   paymentCC: true,
@@ -50,22 +39,99 @@ if (process.browser) {
 }
 
 const HomePage: React.FC = () => {
-  const router = useRouter();
-  const firstTimeRef = useRef(true);
-  const { loginWithPopup, isAuthenticated, isLoading: isAuthenticatedLoading, getIdTokenClaims } = useAuth0();
+  const { isAuthenticated, isLoading: isAuthenticatedLoading } = useAuth0();
   const { data: meData, loading: meLoading, error: meError } = useMeQuery({ skip: !isAuthenticated });
   const isLoading = isAuthenticatedLoading || meLoading;
   const organizations = isLoading ? [] : (meData?.me?.userOrgs || []).map(userOrg => userOrg.organization);
   const hasOrganizations = organizations.length > 0;
 
-  const paymentIdParam = router.query[THREEDS_FLOW_SEARCH_PARAM_SUCCESS_KEY]?.toString();
-  const paymentErrorParam = router.query[THREEDS_FLOW_SEARCH_PARAM_ERROR_KEY]?.toString();
 
-  const { loaderMode, isOpen, onOpen, onClose } = useOpenCloseCheckoutModal({ paymentIdParam, paymentErrorParam });
+  // CHECKOUT OPENING WITH FORM VALUES:
 
-  const onRemoveUrlParams = useCallback((cleanURL: string) => {
-    router.replace(cleanURL, undefined, { shallow: true });
-  }, [router]);
+  const { open, setCheckoutComponentProps } = useCheckoutOverlay();
+
+  const handleOpenClicked = useCallback(() => open(), [open]);
+
+
+  // FORM VALUES:
+
+  const [formValues, setFormValues] = useState<PlaygroundFormData>(DEFAULT_FORM_VALUES);
+
+  const getComponentPropsRef = useRef<() => CheckoutComponentProps>(() => ({}));
+
+  getComponentPropsRef.current = () => {
+    const lotType = formValues.lotType || DEFAULT_FORM_VALUES.lotType;
+
+    return {
+      // Personalization:
+      userFormat: PLAYGROUND_USER_FORMAT,
+      acceptedPaymentTypes: [
+        formValues.paymentCC ? "CreditCard" : "",
+        formValues.paymentACH ? "ACH" : "",
+        formValues.paymentWire ? "Wire" : "",
+        formValues.paymentCrypto ? "Crypto" : "",
+      ].filter(Boolean) as PaymentType[],
+      acceptedCreditCardNetworks: formValues.paymentCC ? ["visa", "mastercard"] : undefined,
+
+      // Data:
+      orgID: (formValues.orgID === "custom" ? formValues.customOrgID : formValues.orgID) || "",
+      invoiceID: (lotType === "auction" && formValues.invoiceID) || "",
+      checkoutItems: [{
+        ...(lotType === "buyNow" ? PLAYGROUND_MOCKED_BUY_NOW_LOT : PLAYGROUND_MOCKED_AUCTION_LOT),
+        lotID: formValues.lotID || DEFAULT_FORM_VALUES.lotID,
+        lotType,
+        units: lotType === "auction" ? 1 : (parseInt(`${formValues.lotUnits || DEFAULT_FORM_VALUES.lotUnits}`, 10) || 1),
+      }],
+    };
+  };
+
+  useEffect(() => {
+    setCheckoutComponentProps(getComponentPropsRef.current());
+
+    setFormValues({
+      // Organization:
+      orgID: INITIAL_FORM_VALUES.orgID ?? DEFAULT_FORM_VALUES.orgID,
+      customOrgID: INITIAL_FORM_VALUES.customOrgID ?? DEFAULT_FORM_VALUES.customOrgID,
+
+      // Invoice (for won auction lots):
+      invoiceID: INITIAL_FORM_VALUES.invoiceID ?? DEFAULT_FORM_VALUES.invoiceID,
+
+      // Lot:
+      lotID: INITIAL_FORM_VALUES.lotID ?? DEFAULT_FORM_VALUES.lotID,
+      lotType: INITIAL_FORM_VALUES.lotType ?? DEFAULT_FORM_VALUES.lotType,
+      lotUnits: INITIAL_FORM_VALUES.lotUnits ?? DEFAULT_FORM_VALUES.lotUnits,
+
+      // Payment:
+      paymentCC: INITIAL_FORM_VALUES.paymentCC ?? DEFAULT_FORM_VALUES.paymentCC,
+      paymentACH: INITIAL_FORM_VALUES.paymentACH ?? DEFAULT_FORM_VALUES.paymentACH,
+      paymentWire: INITIAL_FORM_VALUES.paymentWire ?? DEFAULT_FORM_VALUES.paymentWire,
+      paymentCrypto: INITIAL_FORM_VALUES.paymentCrypto ?? DEFAULT_FORM_VALUES.paymentCrypto,
+    });
+  }, [setCheckoutComponentProps]);
+
+  const handleChange = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value, checked, type } = target;
+
+    setFormValues((prevFormValues) => ({
+      ...prevFormValues,
+      [name]: (type === "radio" || type === "checkbox") && value === "" ? checked : value,
+    }));
+  };
+
+  useEffect(() => {
+    setCheckoutComponentProps(getComponentPropsRef.current());
+
+    try {
+      localStorage.setItem(FORM_VALUES_KEY, JSON.stringify(formValues));
+    } catch (err) {
+      console.log(err);
+    }
+  }, [setCheckoutComponentProps, formValues]);
+
+
+  // AUTO-OPENING (FIRS-TIME ONLY):
+
+  const firstTimeRef = useRef(true);
 
   useEffect(() => {
     if (
@@ -80,184 +146,14 @@ const HomePage: React.FC = () => {
 
     firstTimeRef.current = false;
 
-    onOpen();
-  }, [isLoading, isAuthenticated, meData, hasOrganizations, onOpen]);
+    open();
+  }, [isLoading, isAuthenticated, meData, hasOrganizations, open]);
 
-  const handleGoToClicked = useCallback(() => {
-    router.push("/profile/invoices");
-  }, [router]);
-
-  const handleEvent = useCallback((eventType: CheckoutEventType, eventData: CheckoutEventData) => {
-    if (!isLocalhost()) console.log(`🎯 ${ eventType }`, eventData);
-
-    // console.log(`🎯 ${ eventType }`, eventData);
-  }, []);
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const handleError = useCallback((error: CheckoutModalError) => {
-    // console.log(error);
-  }, []);
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const handleCatch = useCallback((error: Error, errorInfo?: ErrorInfo): void | true => {
-    // console.log(error, errorInfo);
-    // return true;
-  }, []);
-
-  const handleMarketingOptInChange = useCallback((marketingOptIn: boolean) => {
-    console.log(marketingOptIn ? "User subscribed" : "User unsubscribed");
-  }, []);
-
-  const handleLogin = useCallback(async () => {
-    await loginWithPopup({ prompt: "login" });
-
-    const token = await getIdTokenClaims();
-
-    console.log({ token });
-  }, [loginWithPopup, getIdTokenClaims]);
-
-  const [formValues, setFormValues] = useState<PlaygroundFormData>(DEFAULT_FORM_VALUES);
-
-  useEffect(() => {
-    setFormValues({
-      // Organization:
-      orgID: INITIAL_FORM_VALUES.orgID || DEFAULT_FORM_VALUES.orgID,
-      customOrgID: INITIAL_FORM_VALUES.customOrgID || DEFAULT_FORM_VALUES.customOrgID,
-
-      // Invoice (for won auction lots):
-      invoiceID: INITIAL_FORM_VALUES.invoiceID || DEFAULT_FORM_VALUES.invoiceID,
-
-      // Lot:
-      lotID: INITIAL_FORM_VALUES.lotID || DEFAULT_FORM_VALUES.lotID,
-      lotType: INITIAL_FORM_VALUES.lotType || DEFAULT_FORM_VALUES.lotType,
-      lotUnits: INITIAL_FORM_VALUES.lotUnits || DEFAULT_FORM_VALUES.lotUnits,
-
-      // Personalization:
-      theme: INITIAL_FORM_VALUES.theme || DEFAULT_FORM_VALUES.theme,
-      customImages: INITIAL_FORM_VALUES.customImages || DEFAULT_FORM_VALUES.customImages,
-      notAuthPreset: INITIAL_FORM_VALUES.notAuthPreset || DEFAULT_FORM_VALUES.notAuthPreset,
-      authPresets: INITIAL_FORM_VALUES.authPresets || DEFAULT_FORM_VALUES.authPresets,
-
-      // Payment:
-      paymentCC: INITIAL_FORM_VALUES.paymentCC || DEFAULT_FORM_VALUES.paymentCC,
-      paymentACH: INITIAL_FORM_VALUES.paymentACH || DEFAULT_FORM_VALUES.paymentACH,
-      paymentWire: INITIAL_FORM_VALUES.paymentWire || DEFAULT_FORM_VALUES.paymentWire,
-      paymentCrypto: INITIAL_FORM_VALUES.paymentCrypto || DEFAULT_FORM_VALUES.paymentCrypto,
-    });
-  }, []);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(FORM_VALUES_KEY, JSON.stringify(formValues));
-    } catch (err) {
-      console.log(err);
-    }
-  }, [formValues]);
-
-  const handleChange = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value, checked, type } = target;
-
-    setFormValues((prevFormValues) => ({
-      ...prevFormValues,
-      [name]: (type === "radio" || type === "checkbox") && value === "" ? checked : value,
-    }));
-  };
-
-  const testPreset = (isAuthenticated ? PLAYGROUND_AUTH_PRESET[formValues.authPresets] : PLAYGROUND_NO_AUTH_PRESET[formValues.notAuthPreset]) || {};
-  const lotType = formValues.lotType || DEFAULT_FORM_VALUES.lotType;
-
-  const checkoutProps: PUICheckoutProps = {
-    // ProviderInjector:
-    uri: `${config.API_HOSTNAME}/query`,
-
-    // Modal:
-    open: isOpen,
-    onClose,
-    onGoTo: handleGoToClicked,
-
-    // Flow:
-    loaderMode,
-    paymentErrorParam,
-    onRemoveUrlParams,
-    guestCheckoutEnabled: testPreset.guestCheckoutEnabled,
-    productConfirmationEnabled: testPreset.productConfirmationEnabled,
-    // vertexEnabled: false,
-    // threeDSEnabled: false,
-
-    // Personalization:
-    theme: PLAYGROUND_THEMES[formValues.theme],
-
-    /*
-    themeOptions: {
-      // Reference App (https://github.com/mojitoinc/mojito-reference-app/) palette:
-      palette: {
-        primary: {
-          // main: "#FF00FF", // Magenta
-          // contrastText: "#FFFFFF",
-        },
-
-        paymentUI: {
-          // progressBar: "", // Use primary as fallback.
-          // paymentMethodSelectorBorder: "", // Use primary as fallback.
-          // paymentMethodSelectorBackground: "", // Use primary as fallback.
-          // mainButtonBackground: "", // Use primary as fallback.
-          // mainButtonBorderWidth: 0,
-        },
-      },
-    },
-    */
-
-    logoSrc: PLAYGROUND_LOGOS_SRC[formValues.theme],
-    logoSx: PLAYGROUND_LOGOS_SX[formValues.theme],
-    loaderImageSrc: formValues.customImages ? PLAYGROUND_LOADER_IMAGE_SRC : "",
-    purchasingImageSrc: formValues.customImages ? PLAYGROUND_PURCHASING_IMAGE_SRC : "",
-    purchasingMessages: undefined,
-    successImageSrc: "",
-    errorImageSrc: formValues.customImages ? PLAYGROUND_ERROR_IMAGE_SRC : "",
-    userFormat: PLAYGROUND_USER_FORMAT,
-    acceptedPaymentTypes: [
-      formValues.paymentCC ? "CreditCard" : "",
-      formValues.paymentACH ? "ACH" : "",
-      formValues.paymentWire ? "Wire" : "",
-      formValues.paymentCrypto ? "Crypto" : "",
-    ].filter(Boolean) as PaymentType[],
-    acceptedCreditCardNetworks: formValues.paymentCC ? ["visa", "mastercard"] : undefined,
-
-    dictionary: {
-      privacyHref: PLAYGROUND_PRIVACY_HREF,
-      termsOfUseHref: PLAYGROUND_TERMS_OF_USE_HREF,
-    },
-
-    // Legal:
-    consentType: "circle",
-
-    // Data:
-    orgID: (formValues.orgID === "custom" ? formValues.customOrgID : formValues.orgID) || "",
-    invoiceID: (lotType === "auction" && formValues.invoiceID) || "",
-    checkoutItems: [{
-      ...(lotType === "buyNow" ? PLAYGROUND_MOCKED_BUY_NOW_LOT : PLAYGROUND_MOCKED_AUCTION_LOT),
-      lotID: formValues.lotID || DEFAULT_FORM_VALUES.lotID,
-      lotType,
-      units: lotType === "auction" ? 1 : (parseInt(`${formValues.lotUnits || DEFAULT_FORM_VALUES.lotUnits}`, 10) || 1),
-    }],
-
-    // Authentication:
-    onLogin: handleLogin,
-    isAuthenticated,
-    isAuthenticatedLoading,
-
-    // Other Events:
-    debug: true,
-    onEvent: handleEvent,
-    onError: handleError,
-    onCatch: handleCatch,
-    onMarketingOptInChange: handleMarketingOptInChange,
-  };
 
   return (<>
     <Box sx={{ my: 4 }}>
       <Stack spacing={2} direction="row">
-        <Button variant="contained" onClick={onOpen} disabled={isLoading}>Open Checkout Modal</Button>
+        <Button variant="contained" onClick={handleOpenClicked} disabled={isLoading}>Open Checkout Modal</Button>
       </Stack>
     </Box>
 
@@ -354,37 +250,6 @@ const HomePage: React.FC = () => {
 
     <Box sx={{ my: 4 }}>
       <FormControl component="fieldset">
-        <FormLabel component="legend">Theme</FormLabel>
-        <RadioGroup
-          name="theme"
-          value={formValues.theme}
-          onChange={handleChange}
-        >
-          <FormControlLabel
-            value="light"
-            control={<Radio />}
-            label="Mojito Light"
-          />
-          <FormControlLabel
-            value="dark"
-            control={<Radio />}
-            label="Mojito Dark"
-          />
-        </RadioGroup>
-      </FormControl>
-    </Box>
-
-    <Box sx={{ my: 4 }}>
-      <FormControl component="fieldset">
-        <FormLabel component="legend">Images</FormLabel>
-        <FormControlLabel label="Custom Purchasing & Error images." control={
-          <Switch name="customImages" checked={formValues.customImages} value="" onChange={handleChange} />
-        } />
-      </FormControl>
-    </Box>
-
-    <Box sx={{ my: 4 }}>
-      <FormControl component="fieldset">
         <FormLabel component="legend">Payment Methods</FormLabel>
         <FormGroup>
           <FormControlLabel control={<Checkbox checked={formValues.paymentCC} value="" onChange={handleChange} name="paymentCC" />} label="Credit Card" />
@@ -395,41 +260,14 @@ const HomePage: React.FC = () => {
       </FormControl>
     </Box>
 
-    <Box sx={{ my: 4 }}>
-      <FormControl component="fieldset" disabled={isAuthenticatedLoading || isAuthenticated}>
-        <FormLabel component="legend">Not Authenticated Presets</FormLabel>
-        <RadioGroup
-          name="notAuthPreset"
-          value={formValues.notAuthPreset}
-          onChange={handleChange}>
-          <FormControlLabel value="noAuthGuestDisabled" control={<Radio />} label="Guest Checkout Disabled (and Product Confirmation Enabled)" />
-          <FormControlLabel value="noAuthGuestEnabled" control={<Radio />} label="Guest Checkout Enabled (and Product Confirmation Enabled)" />
-        </RadioGroup>
-        {(isAuthenticatedLoading || isAuthenticated) && <FormHelperText>You must not be authenticated.</FormHelperText>}
-      </FormControl>
-    </Box>
-
-    <Box sx={{ my: 4 }}>
-      <FormControl component="fieldset" disabled={isAuthenticatedLoading || !isAuthenticated}>
-        <FormLabel component="legend">Authenticated Presets</FormLabel>
-        <RadioGroup
-          name="authPresets"
-          value={formValues.authPresets}
-          onChange={handleChange}>
-          <FormControlLabel value="authConfirmationDisabled" control={<Radio />} label="Skip Product Confirmation" />
-          <FormControlLabel value="authConfirmationEnabledNoGuest" control={<Radio />} label="Guest Checkout Disabled + With Product Confirmation" />
-          <FormControlLabel value="authConfirmationEnabledGuest" control={<Radio />} label="Guest Checkout Enabled + With Product Confirmation (not implemented)" />
-        </RadioGroup>
-        {(isAuthenticatedLoading || !isAuthenticated) && <FormHelperText>You must be authenticated.</FormHelperText>}
-      </FormControl>
-    </Box>
 
     <Box sx={{ my: 4 }}>
       <Stack spacing={2} direction="row">
-        <Button variant="contained" onClick={onOpen} disabled={isLoading}>Open Checkout Modal</Button>
+        <Button variant="contained" onClick={handleOpenClicked} disabled={isLoading}>Open Checkout Modal</Button>
       </Stack>
     </Box>
 
+    { /*
     <Box component="pre" sx={{ my: 4, p: 2, overflow: "scroll", border: 2, borderRadius: "4px" }}>
       {JSON.stringify(checkoutProps, (key, value) => {
         if (typeof value === "function") return value.name ? `function ${value.name}` : "() => { ... }";
@@ -441,9 +279,10 @@ const HomePage: React.FC = () => {
 
     <Box sx={{ my: 4 }}>
       <Stack spacing={2} direction="row">
-        <Button variant="contained" onClick={onOpen} disabled={isLoading}>Open Checkout Modal</Button>
+        <Button variant="contained" onClick={handleOpenClicked} disabled={isLoading}>Open Checkout Modal</Button>
       </Stack>
     </Box>
+    */ }
 
     <Box sx={{ my: 2 }}>
       {PLAYGROUND_PARAGRAPHS_ARRAY.map((paragraph, index) => (
@@ -453,11 +292,9 @@ const HomePage: React.FC = () => {
 
     <Box sx={{ my: 4 }}>
       <Stack spacing={2} direction="row">
-        <Button variant="contained" onClick={onOpen} disabled={isLoading}>Open Checkout Modal</Button>
+        <Button variant="contained" onClick={handleOpenClicked} disabled={isLoading}>Open Checkout Modal</Button>
       </Stack>
     </Box>
-
-    <PUICheckout {...checkoutProps} />
   </>);
 };
 

--- a/app/src/pages/oauth.tsx
+++ b/app/src/pages/oauth.tsx
@@ -1,8 +1,7 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { useCallback } from "react";
-import { PUIPlaid } from "../lib";
-import { PLAYGROUND_THEMES } from "../utils/playground/playground.constants";
+import { MOJITO_LIGHT_THEME, PUIPlaid } from "../lib";
 
 const PlaidOAuthPage: NextPage = () => {
   const router = useRouter();
@@ -19,7 +18,7 @@ const PlaidOAuthPage: NextPage = () => {
 
   return (
     <PUIPlaid
-      theme={PLAYGROUND_THEMES.light}
+      theme={MOJITO_LIGHT_THEME}
       onRedirect={handleRedirect} />
   );
 }

--- a/app/src/pages/payments/error.tsx
+++ b/app/src/pages/payments/error.tsx
@@ -1,9 +1,9 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { useCallback } from "react";
-import { PUIError } from "../../lib";
+import { MOJITO_LIGHT_THEME, PUIError } from "../../lib";
 import { config } from "../../utils/config/config.constants";
-import { PLAYGROUND_THEMES, PLAYGROUND_LOGOS_SRC, PLAYGROUND_LOGOS_SX } from "../../utils/playground/playground.constants";
+import { PLAYGROUND_MOJITO_LOGO } from "../../utils/playground/playground.constants";
 
 const ErrorPage: NextPage = () => {
   const router = useRouter();
@@ -21,9 +21,8 @@ const ErrorPage: NextPage = () => {
   return (
     <PUIError
       uri={ `${ config.API_HOSTNAME }/query` }
-      theme={ PLAYGROUND_THEMES.light }
-      logoSrc={ PLAYGROUND_LOGOS_SRC.light }
-      logoSx={ PLAYGROUND_LOGOS_SX.light }
+      theme={MOJITO_LIGHT_THEME}
+      logoSrc={PLAYGROUND_MOJITO_LOGO}
       errorImageSrc=""
       onRedirect={ handleRedirect } />
   );

--- a/app/src/pages/payments/success.tsx
+++ b/app/src/pages/payments/success.tsx
@@ -1,8 +1,8 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { useCallback } from "react";
-import { PUISuccess } from "../../lib";
-import { PLAYGROUND_LOGOS_SRC, PLAYGROUND_LOGOS_SX, PLAYGROUND_THEMES } from "../../utils/playground/playground.constants";
+import { MOJITO_LIGHT_THEME, PUISuccess } from "../../lib";
+import { PLAYGROUND_MOJITO_LOGO } from "../../utils/playground/playground.constants";
 
 const SuccessPage: NextPage = () => {
   const router = useRouter();
@@ -19,9 +19,8 @@ const SuccessPage: NextPage = () => {
 
   return (
     <PUISuccess
-      theme={PLAYGROUND_THEMES.light}
-      logoSrc={PLAYGROUND_LOGOS_SRC.light}
-      logoSx={PLAYGROUND_LOGOS_SX.light}
+      theme={MOJITO_LIGHT_THEME}
+      logoSrc={PLAYGROUND_MOJITO_LOGO}
       successImageSrc=""
       onRedirect={handleRedirect} />
   );

--- a/app/src/utils/playground/playground.constants.ts
+++ b/app/src/utils/playground/playground.constants.ts
@@ -1,67 +1,16 @@
-import { PUICheckoutProps, UserFormat } from "../../lib";
-import { PlaygroundAuthPresetFieldValues, PlaygroundNoAuthPresetFieldValues, PlaygroundThemeFieldValues } from "./playground.interfaces";
+import { UserFormat } from "../../lib";
 import { CheckoutItemInfo } from "../../lib/domain/product/product.interfaces";
-import { MOJITO_LIGHT_THEME, MOJITO_DARK_THEME } from "../../lib/config/theme/theme";
-import { SxProps, Theme } from "@mui/material/styles";
 
 export const PLAYGROUND_LOREM_IPSUM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 export const PLAYGROUND_PARAGRAPHS_ARRAY = new Array(32).fill(PLAYGROUND_LOREM_IPSUM);
 
 
-// Flow:
-
-export const PLAYGROUND_NO_AUTH_PRESET: Record<PlaygroundNoAuthPresetFieldValues, Partial<PUICheckoutProps>> = {
-  noAuthGuestDisabled: {
-    guestCheckoutEnabled: false,
-    productConfirmationEnabled: true,
-  },
-  noAuthGuestEnabled: {
-    guestCheckoutEnabled: true,
-    productConfirmationEnabled: true,
-  },
-};
-
-export const PLAYGROUND_AUTH_PRESET: Record<PlaygroundAuthPresetFieldValues, Partial<PUICheckoutProps>> = {
-  authConfirmationDisabled: {
-    guestCheckoutEnabled: false,
-    productConfirmationEnabled: false,
-  },
-  authConfirmationEnabledNoGuest: {
-    guestCheckoutEnabled: false,
-    productConfirmationEnabled: true,
-  },
-  authConfirmationEnabledGuest: {
-    guestCheckoutEnabled: true,
-    productConfirmationEnabled: true,
-  },
-};
-
-
 // Personalization:
-export const PLAYGROUND_THEMES: Record<PlaygroundThemeFieldValues, Theme> = {
-  light: MOJITO_LIGHT_THEME,
-  dark: MOJITO_DARK_THEME,
-};
 
-export const PLAYGROUND_LOGOS_SRC: Record<PlaygroundThemeFieldValues, string> = {
-  light: "/img/logos/mojito-light-logo.svg",
-  dark: "/img/logos/mojito-dark-logo.svg",
-};
-
-export const PLAYGROUND_LOGOS_SX: Record<PlaygroundThemeFieldValues, SxProps<Theme>> = {
-  light: {},
-  dark: {},
-};
-
-export const PLAYGROUND_LOADER_IMAGE_SRC = "https://media3.giphy.com/media/YpqWbjNDq8y4DVu4BO/giphy.gif?cid=ecf05e47hoq39f52knk6b767w9234wjjf9kg1yw319oqcpyx&rid=giphy.gif&ct=g";
-export const PLAYGROUND_PURCHASING_IMAGE_SRC = "https://media0.giphy.com/media/mGNO9zHJpV9JOVRz1L/giphy.gif?cid=ecf05e472c8qhocoaupl2nor86fm54x1fjk0o7flma4umpzx&rid=giphy.gif&ct=g";
-export const PLAYGROUND_ERROR_IMAGE_SRC = "https://media0.giphy.com/media/TqiwHbFBaZ4ti/giphy.gif?cid=ecf05e47mu7l08ab2eap2z3iznda6icrd0m0lmu2fdi78ra5&rid=giphy.gif&ct=g";
+export const PLAYGROUND_MOJITO_LOGO = "/img/logos/mojito-light-logo.svg";
 
 export const PLAYGROUND_USER_FORMAT: UserFormat = "email";
 
-export const PLAYGROUND_PRIVACY_HREF = "https://mojito.xyz";
-
-export const PLAYGROUND_TERMS_OF_USE_HREF = "https://mojito.xyz";
 
 // Data
 

--- a/app/src/utils/playground/playground.interfaces.ts
+++ b/app/src/utils/playground/playground.interfaces.ts
@@ -1,11 +1,5 @@
 import { LotType } from "../../lib/domain/product/product.interfaces";
 
-export type PlaygroundNoAuthPresetFieldValues = "noAuthGuestDisabled" | "noAuthGuestEnabled";
-
-export type PlaygroundAuthPresetFieldValues = "authConfirmationDisabled" | "authConfirmationEnabledNoGuest" | "authConfirmationEnabledGuest";
-
-export type PlaygroundThemeFieldValues = "light" | "dark";
-
 export interface PlaygroundFormData {
   // Organization:
   orgID: string;
@@ -18,12 +12,6 @@ export interface PlaygroundFormData {
   lotID: string;
   lotType: LotType;
   lotUnits: number;
-
-  // Personalization:
-  theme: PlaygroundThemeFieldValues;
-  customImages: boolean;
-  notAuthPreset: PlaygroundNoAuthPresetFieldValues;
-  authPresets: PlaygroundAuthPresetFieldValues;
 
   // Payment:
   paymentCC: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojitoinc/mojito-mixers",
-  "version": "1.1.2-alpha",
+  "version": "1.2.1-alpha",
   "description": "",
   "main": "dist/cjs/src/index.js",
   "module": "dist/esm/src/index.js",


### PR DESCRIPTION
This fixes/removes the flickering when being redirected to/from 3DS in frontend setups where the Payment UI or even the page that has to show it are not rendered in the initial page load.