### PR TITLE
MRKT-52: Fixes error retry / handling logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Error, exception and validation messages in the Payment UI are displayed in the 
 and have a configurable button text and action (what the button does or where it takes users when clicking it). Particularly,
 those actions are:
 
+- `close`: Closes the payment modal.
 - `reset`: Re-creates the reservation/invoice.
 - `authentication`: Takes users to the authentication view (currently not used).
 - `billing`: Takes users to the billing view/form.
@@ -299,47 +300,51 @@ Defined in [`app/src/lib/domain/errors/errors.constants.ts`](https://github.com/
 
 - `ERROR_GENERIC = ` An unexpected error happened.
 
-  `action = payment`
+  `action = close`
 
 - `ERROR_LOADING = ` Loading error details...
 
-  `action = none`
+  `action = close`
+
+- `ERROR_LOADING_TIMEOUT = ` The purchase could not be completed.
+
+  `action = payment`
 
 - `ERROR_LOADING_USER = ` User could not be loaded.
 
-  `action = billing`
+  `action = reset`
 
 - `ERROR_LOADING_PAYMENT_METHODS = ` Payment methods could not be loaded.
 
-  `action = billing`
+  `action = reset`
 
 - `ERROR_LOADING_INVOICE = ` Invoice could not be loaded.
 
-  `action = billing`
+  `action = reset`
 
-- `ERROR_PURCHASE = ` The purchase could not be completed.
+- `ERROR_INVOICE_TIMEOUT = ` Your product reservation expired. Please, try to complete the purchase again in time.
 
-  `action = payment`
+  `action = reset`
 
 - `ERROR_PURCHASE_TIMEOUT = ` The purchase could not be completed in time.
 
-  `action = payment`
+  `action = purchasing`
 
 - `ERROR_PURCHASE_NO_ITEMS = ` No items to purchase.
 
-  `action = payment`
+  `action = close`
 
 - `ERROR_PURCHASE_NO_UNITS = ` No units to purchase.
 
-  `action = payment`
+  `action = close`
 
 - `ERROR_PURCHASE_LOADING_ITEMS = ` Purchase items could not be loaded.
 
-  `action = payment`
+  `action = close`
 
 - `ERROR_PURCHASE_SELECTED_PAYMENT_METHOD = ` Could not find the selected payment method.
 
-  `action = payment`
+  `action = reset`
 
 - `ERROR_PURCHASE_CREATING_PAYMENT_METHOD = ` Payment method could not be saved.
 
@@ -355,15 +360,7 @@ Defined in [`app/src/lib/domain/errors/errors.constants.ts`](https://github.com/
 
 - `ERROR_PURCHASE_PAYING = ` Payment failed.
 
-  `action = payment`
-
-- `ERROR_PURCHASE_3DS = ` Payment method could not be verified.
-
-  `action = payment`
-
-- `ERROR_INVOICE_TIMEOUT = ` Your product reservation expired. Please, try to complete the purchase again in time.
-
-  `action = reset`
+  `action = purchasing`
 
 <br />
 
@@ -371,11 +368,11 @@ Additionally, there are some backend errors that are mapped to frontend ones:
 
 - `lot auction not started = ` The auction has not started yet.
 
-  `action = reset`
+  `action = close`
 
 - `payment limit exceeded = ` You have already bought the maximum number of NFTs allowed for this sale.
 
-  `action = reset`
+  `action = close`
 
 - `name should contains first and last name = ` Full Name must have at least first and last name.
 

--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -78,7 +78,7 @@ module.exports = {
 
     "import/extensions": 0,
     "import/no-cycle": TEMPORARILY_DISABLED,
-    "import/no-extraneous-dependencies": ["error", { devDependencies: ["**/*.test.ts", "**/*.test.tsx", "jest.setup.ts"] }],
+    "import/no-extraneous-dependencies": ["error", { devDependencies: ["**/*.test.ts", "**/*.test.tsx", "jest.setup.ts", "jest.config.js"] }],
     "import/no-unresolved": 2,
     "import/prefer-default-export": 0,
 

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -1,6 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+/* eslint-disable @typescript-eslint/no-var-requires */
+
 const { pathsToModuleNameMapper } = require("ts-jest");
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { compilerOptions } = require("./tsconfig.json");
 
 const paths = pathsToModuleNameMapper(compilerOptions.paths, {

--- a/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.hooks.ts
+++ b/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.hooks.ts
@@ -13,8 +13,7 @@ import { resetStepperProgress } from "../../payments/CheckoutStepper/CheckoutSte
 import { CheckoutModalStateCombined } from "./CheckoutOverlay.types";
 import { getCheckoutModalState } from "./CheckoutOverlay.utils";
 
-// TODO: Add a "close" value here:
-export type CheckoutModalErrorAt = "reset" | "authentication" | "billing" | "payment" | "purchasing";
+export type CheckoutModalErrorAt = "close" | "reset" | "authentication" | "billing" | "payment" | "purchasing";
 
 export interface CheckoutModalError {
   at?: CheckoutModalErrorAt;

--- a/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.tsx
+++ b/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.tsx
@@ -20,7 +20,7 @@ import { RawSavedPaymentMethod, SavedPaymentMethod } from "../../../domain/circl
 import { continuePlaidOAuthFlow, PlaidFlow } from "../../../hooks/usePlaid";
 import { ConsentType } from "../../shared/ConsentText/ConsentText";
 import { CheckoutModalError, CheckoutModalStepIndex, useCheckoutModalState } from "./CheckoutOverlay.hooks";
-import { DEFAULT_ERROR_AT, ERROR_LOADING_INVOICE, ERROR_LOADING_PAYMENT_METHODS, ERROR_LOADING_USER } from "../../../domain/errors/errors.constants";
+import { ERROR_LOADING_INVOICE, ERROR_LOADING_PAYMENT_METHODS, ERROR_LOADING_USER } from "../../../domain/errors/errors.constants";
 import { FullScreenOverlay } from "../../shared/FullScreenOverlay/FullScreenOverlay";
 import { ProvidersInjectorProps, withProviders } from "../../shared/ProvidersInjector/ProvidersInjector";
 import { transformCheckoutItemsFromInvoice } from "../../../domain/product/product.utils";
@@ -719,7 +719,9 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
   const handleFixError = useCallback(async (): Promise<false> => {
     const at = checkoutError?.at;
 
-    if (at === "reset") {
+    if (at === "close") {
+      handleClose();
+    } else if (at === "reset") {
       await Promise.allSettled([
         meRefetch(),
         refetchPaymentMethods().catch(() => { /* TODO: Handle this error properly. */ }),
@@ -743,14 +745,14 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
         setSelectedPaymentMethod(prevSelectedPaymentMethod => ({ ...prevSelectedPaymentMethod, cvv: "" }));
       }
 
-      goTo(at || DEFAULT_ERROR_AT, checkoutError);
+      goTo(at, checkoutError);
     }
 
     // This function is used as a CheckoutModalFooter's onSubmitClicked, so we want that to show a loader on the submit
     // button when clicked but do not remove it once the Promise is resolved, as we are moving to another view and
     // CheckoutModalFooter will unmount (so doing this prevents a memory leak issue):
     return false;
-  }, [checkoutError, goTo, createInvoiceAndReservation, meRefetch, refetchPaymentMethods, refetchInvoiceDetails, setSelectedPaymentMethod]);
+  }, [checkoutError, handleClose, meRefetch, refetchPaymentMethods, createInvoiceAndReservation, goTo, refetchInvoiceDetails, setSelectedPaymentMethod]);
 
 
   // Plaid integration (resume Plaid flow):

--- a/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.tsx
+++ b/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.tsx
@@ -259,8 +259,12 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
     refetch: refetchPaymentMethods,
   } = useGetPaymentMethodListQuery({
     skip: !isAuthenticated || !orgID || !open,
-    variables: { orgID },
+    variables: { orgID: "" },
   });
+
+  const handleSavedPaymentMethodsReloaded = useCallback(async () => {
+    await refetchPaymentMethods({ orgID }).catch(() => { /* paymentMethodsError above will get a value and show in BillingInfoForm */ });
+  }, [refetchPaymentMethods, orgID]);
 
 
   // Once we have an invoiceID, load the invoice:
@@ -408,17 +412,9 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
     if (meError) setError(ERROR_LOADING_USER(meError));
     if (invoiceDetailsError) setError(ERROR_LOADING_INVOICE(invoiceDetailsError));
 
-    // TODO: We could add an option to configure if we want to ignore this error:
-    const ignorePaymentMethodsError = true;
-
-    if (paymentMethodsError) {
-      if (ignorePaymentMethodsError) {
-        if (debug) console.log("\n❌ (IGNORED) Error loading saved payment methods:\n\n", paymentMethodsError);
-      } else {
-        setError(ERROR_LOADING_PAYMENT_METHODS(paymentMethodsError));
-      }
-    }
-  }, [meError, invoiceDetailsError, paymentMethodsError, debug, setError]);
+    // This one doesn't show the ErrorView. Instead, it's displayed inline in the BillingView > BillingInfoForm:
+    if (paymentMethodsError) goTo(undefined, ERROR_LOADING_PAYMENT_METHODS(paymentMethodsError));
+  }, [meError, invoiceDetailsError, paymentMethodsError, debug, goTo, setError]);
 
 
   // Analytics:
@@ -587,8 +583,8 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
 
     await Promise.allSettled(promises);
 
-    await refetchPaymentMethods().catch(() => { /* TODO: Handle this error properly. */ });
-  }, [checkoutStep, deletePaymentMethod, orgID, refetchPaymentMethods, savedPaymentMethods, setSelectedPaymentMethod]);
+    await handleSavedPaymentMethodsReloaded();
+  }, [checkoutStep, deletePaymentMethod, orgID, savedPaymentMethods, setSelectedPaymentMethod, handleSavedPaymentMethodsReloaded]);
 
 
   // Purchase:
@@ -609,20 +605,20 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
     }
 
     // After a successful purchase, a new payment method might have been created, so we reload them:
-    await refetchPaymentMethods().catch(() => { /* TODO: Handle this error properly. */ });
+    await handleSavedPaymentMethodsReloaded();
 
     goNext();
-  }, [setPayments, debug, refetchPaymentMethods, goNext]);
+  }, [setPayments, debug, handleSavedPaymentMethodsReloaded, goNext]);
 
   const handlePurchaseError = useCallback(async (error?: string | CheckoutModalError) => {
     setTimeout(() => triggerAnalyticsEventRef.current("event:paymentError"));
 
     // After a failed purchase, a new payment method might have been created anyway, so we reload them (createPaymentMethod
     // works but createPayment fails):
-    await refetchPaymentMethods().catch(() => { /* TODO: Handle this error properly. */ });
+    await handleSavedPaymentMethodsReloaded();
 
     setError(error);
-  }, [refetchPaymentMethods, setError]);
+  }, [handleSavedPaymentMethodsReloaded, setError]);
 
 
   // Release reservation:
@@ -724,7 +720,7 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
     } else if (at === "reset") {
       await Promise.allSettled([
         meRefetch(),
-        refetchPaymentMethods().catch(() => { /* TODO: Handle this error properly. */ }),
+        handleSavedPaymentMethodsReloaded(),
         createInvoiceAndReservation(),
       ]);
 
@@ -736,7 +732,7 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
       // method has been created despite the error:
       await Promise.allSettled([
         meRefetch(),
-        refetchPaymentMethods().catch(() => { /* TODO: Handle this error properly. */ }),
+        handleSavedPaymentMethodsReloaded(),
         refetchInvoiceDetails(),
       ]);
 
@@ -752,7 +748,16 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
     // button when clicked but do not remove it once the Promise is resolved, as we are moving to another view and
     // CheckoutModalFooter will unmount (so doing this prevents a memory leak issue):
     return false;
-  }, [checkoutError, handleClose, meRefetch, refetchPaymentMethods, createInvoiceAndReservation, goTo, refetchInvoiceDetails, setSelectedPaymentMethod]);
+  }, [
+    checkoutError,
+    handleClose,
+    meRefetch,
+    handleSavedPaymentMethodsReloaded,
+    createInvoiceAndReservation,
+    goTo,
+    refetchInvoiceDetails,
+    setSelectedPaymentMethod,
+  ]);
 
 
   // Plaid integration (resume Plaid flow):
@@ -855,6 +860,7 @@ export const PUICheckoutOverlay: React.FC<PUICheckoutOverlayProps> = ({
         checkoutError={ checkoutError }
         onBillingInfoSelected={ handleBillingInfoSelected }
         onTaxesChange={ setTaxes }
+        onReloadSavedPaymentMethods={ handleSavedPaymentMethodsReloaded }
         onSavedPaymentMethodDeleted={ handleSavedPaymentMethodDeleted }
         onWalletChange={ setWalletAddress }
         onNext={ goNext }

--- a/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.types.ts
+++ b/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.types.ts
@@ -17,9 +17,9 @@ export interface CheckoutModalInfoCommon {
 }
 
 export interface CheckoutModalInfo3DS extends CheckoutModalInfoCommon {
-  processorPaymentID: string; // TODO: This might be needed to match confirmation screens (use it in the localStorage key).
+  processorPaymentID: string;
   paymentID: string;
-  paymentInfo: string | null;
+  paymentInfo: string;
   checkoutItems: CheckoutItemInfo[];
 }
 

--- a/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.utils.ts
+++ b/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.utils.ts
@@ -21,6 +21,8 @@ export function persistCheckoutModalInfo(info: CheckoutModalInfo) {
   try {
     const url = info.url || getUrlWithoutParams();
 
+    console.log("isCheckoutModalInfo3DS(info) =", isCheckoutModalInfo3DS(info));
+
     // Multiple cookies for different 3DS payments can co-exist for a brief time. Plaid ones can't, as they share the same key:
     cookieStorage.setItem(CHECKOUT_MODAL_INFO_KEY(isCheckoutModalInfo3DS(info) ? info.processorPaymentID : CHECKOUT_MODAL_INFO_KEY_PLAID_SUFFIX), {
       ...info,

--- a/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.utils.ts
+++ b/app/src/lib/components/public/CheckoutOverlay/CheckoutOverlay.utils.ts
@@ -21,8 +21,6 @@ export function persistCheckoutModalInfo(info: CheckoutModalInfo) {
   try {
     const url = info.url || getUrlWithoutParams();
 
-    console.log("isCheckoutModalInfo3DS(info) =", isCheckoutModalInfo3DS(info));
-
     // Multiple cookies for different 3DS payments can co-exist for a brief time. Plaid ones can't, as they share the same key:
     cookieStorage.setItem(CHECKOUT_MODAL_INFO_KEY(isCheckoutModalInfo3DS(info) ? info.processorPaymentID : CHECKOUT_MODAL_INFO_KEY_PLAID_SUFFIX), {
       ...info,

--- a/app/src/lib/components/public/ErrorOverlay/ErrorOverlay.tsx
+++ b/app/src/lib/components/public/ErrorOverlay/ErrorOverlay.tsx
@@ -1,7 +1,7 @@
 import { useTimeout } from "@swyg/corre";
 import React, { useCallback, useLayoutEffect, useState, useEffect } from "react";
 import { PAYMENT_NOTIFICATION_ERROR_MAX_WAIT_MS, PAYMENT_NOTIFICATION_INTERVAL_MS, THREEDS_FLOW_SEARCH_PARAM_ERROR_KEY } from "../../../config/config";
-import { ERROR_PURCHASE } from "../../../domain/errors/errors.constants";
+import { ERROR_LOADING_TIMEOUT } from "../../../domain/errors/errors.constants";
 import { PUIRouterOptions } from "../../../domain/router/router.types";
 import { isUrlPathname } from "../../../domain/url/url.utils";
 import { useGetPaymentNotificationQuery } from "../../../queries/graphqlGenerated";
@@ -33,7 +33,7 @@ export const PUIErrorOverlay: React.FC<PUIErrorOverlayProps> = ({
   }, [error]);
 
   useTimeout(() => {
-    setErrorMessage(prevErrorMessage => prevErrorMessage || ERROR_PURCHASE.errorMessage);
+    setErrorMessage(prevErrorMessage => prevErrorMessage || ERROR_LOADING_TIMEOUT.errorMessage);
   }, PAYMENT_NOTIFICATION_ERROR_MAX_WAIT_MS);
 
   // TODO: Remove this from render body:

--- a/app/src/lib/components/shared/SavedBillingDetailsSelector/SavedBillingDetailsSelector.tsx
+++ b/app/src/lib/components/shared/SavedBillingDetailsSelector/SavedBillingDetailsSelector.tsx
@@ -93,7 +93,7 @@ export const SavedBillingDetailsSelector: React.FC<SavedBillingDetailsSelectorPr
         variant="toPayment"
         consentType={ consentType }
         submitLabel={ taxes?.status === "loading" ? "Calculating taxes..." : undefined }
-        submitDisabled={ !!taxes && taxes.status === "loading" }
+        submitDisabled={ showLoader || (!!taxes && taxes.status === "loading") }
         onSubmitClicked={ handleNextClicked }
         onCloseClicked={ onClose } />
     </>

--- a/app/src/lib/components/shared/Select/CountrySelector/CountrySelector.tsx
+++ b/app/src/lib/components/shared/Select/CountrySelector/CountrySelector.tsx
@@ -51,7 +51,7 @@ export const CountrySelector: React.FC<CountrySelectorProps> = ({
   return (
     <Select
       { ...props }
-      // See https://developers.google.com/web/updates/2015/06/checkout-faster-with-autofill:
+      // See https://developers.google.com/web/updates/2015/06/checkout-faster-with-autofill
       autoComplete={ props.autoComplete || "country" }
       label={ label }
       options={ options }

--- a/app/src/lib/components/shared/Select/StateSelector/StateSelector.tsx
+++ b/app/src/lib/components/shared/Select/StateSelector/StateSelector.tsx
@@ -18,36 +18,30 @@ export const StateSelector: React.FC<StateSelectorProps> = ({
   countryCode,
   ...props
 }) => {
-  const initRef = useRef(false);
+  const optionFromCountryRef = useRef<string | number>(countryCode);
 
   const { options, optionsMap } = useCountryOptions(countryCode);
 
   const handleChange = useCallback((e: SelectChangeEvent<string | number>) => {
+    optionFromCountryRef.current = countryCode;
+
     onSelectState(optionsMap[e.target.value]);
-  }, [optionsMap, onSelectState]);
+  }, [countryCode, optionsMap, onSelectState]);
 
   const isDisabled = disabled || !countryCode || options.length === 0;
 
-  // If the selected country code changes, we reset the field. Note the useEffect below might not do that, as two
-  // different countries might have states with the same code (eg. Andorra and Anguilla):
-  useEffect(() => {
-    if (!initRef.current) {
-      initRef.current = true;
-
-      return;
-    }
-
-    onSelectState(EMPTY_OPTION);
-  }, [countryCode, onSelectState]);
-
-  // If the selected option can't be found among the available ones, we reset the field:
+  // If the selected option can't be found among the available ones, or if the selected country code changes, we reset
+  // the field (note the optionFromCountryRef takes care of handling states of different countries that have the same
+  // code, such as Andorra and Anguilla):
   useEffect(() => {
     const stateCode = value.value;
 
     if (isDisabled || !stateCode) return;
 
-    if (!optionsMap[stateCode]) onSelectState(EMPTY_OPTION);
-  }, [value, isDisabled, optionsMap, onSelectState]);
+    const optionFromCountry = optionFromCountryRef.current;
+
+    if (!optionsMap[stateCode] || (optionFromCountry && optionFromCountry !== countryCode)) onSelectState(EMPTY_OPTION);
+  }, [value, isDisabled, optionsMap, onSelectState, countryCode]);
 
   // If the selected option only has one property set, we try to find a match:
   useEffect(() => {
@@ -55,11 +49,17 @@ export const StateSelector: React.FC<StateSelectorProps> = ({
 
     if ((selectedValue && selectedLabel) || (!selectedValue && !selectedLabel) || options.length === 0) return;
 
-    const option = selectedValue
-      ? optionsMap[selectedValue]
-      : options.find(opt => opt.label === selectedLabel);
+    const option = (
+      selectedValue
+        ? optionsMap[selectedValue]
+        : options.find(opt => opt.label === selectedLabel)
+    ) || EMPTY_OPTION;
 
-    setTimeout(() => onSelectState(option || EMPTY_OPTION));
+    console.log(optionFromCountryRef.current === countryCode ? "NOOP 2" : "RESET 2");
+
+    onSelectState(optionFromCountryRef.current === countryCode ? option : EMPTY_OPTION);
+
+    // setTimeout(() => onSelectState(option || EMPTY_OPTION));
   }, [value, optionsMap, options, onSelectState, countryCode]);
 
   const selectedValue = value.value;
@@ -68,7 +68,7 @@ export const StateSelector: React.FC<StateSelectorProps> = ({
     <Select
       { ...props }
       // See https://developers.google.com/web/updates/2015/06/checkout-faster-with-autofill:
-      autoComplete={ props.autoComplete || "state" }
+      autoComplete={ props.autoComplete || "region" }
       label={ label }
       options={ options }
       onChange={ handleChange }

--- a/app/src/lib/components/shared/Select/StateSelector/StateSelector.tsx
+++ b/app/src/lib/components/shared/Select/StateSelector/StateSelector.tsx
@@ -55,11 +55,7 @@ export const StateSelector: React.FC<StateSelectorProps> = ({
         : options.find(opt => opt.label === selectedLabel)
     ) || EMPTY_OPTION;
 
-    console.log(optionFromCountryRef.current === countryCode ? "NOOP 2" : "RESET 2");
-
     onSelectState(optionFromCountryRef.current === countryCode ? option : EMPTY_OPTION);
-
-    // setTimeout(() => onSelectState(option || EMPTY_OPTION));
   }, [value, optionsMap, options, onSelectState, countryCode]);
 
   const selectedValue = value.value;

--- a/app/src/lib/config/config.ts
+++ b/app/src/lib/config/config.ts
@@ -41,6 +41,7 @@ export const CHECKOUT_MODAL_INFO_KEY_PLAID_SUFFIX = "PLAID";
 export const CHECKOUT_MODAL_INFO_REDIRECT_URI_KEY = "CHECKOUT_MODAL_INFO_REDIRECT_URI";
 export const CHECKOUT_MODAL_INFO_USED_KEY = "CHECKOUT_MODAL_INFO_USED";
 
+
 // Plaid:
 export const PLAID_STORAGE_EXPIRATION_MS = 15 * 60000; // 15 minutes (Plaid requires filling in some data).
 export const PLAID_OAUTH_FLOW_URL_SEARCH = "?oauth_state_id=";
@@ -52,7 +53,5 @@ export const THREEDS_FLOW_SEARCH_PARAM_SUCCESS_KEY = "paymentId";
 export const THREEDS_FLOW_SEARCH_PARAM_ERROR_KEY = "paymentError";
 export const THREEDS_SUCCESS_URL_REG_EXP = /success/;
 export const THREEDS_ERROR_URL_REG_EXP = /payments\/(error|failure)/;
-
 export const THREEDS_REDIRECT_DELAY_MS = 1000; // (1 sec) Small delay before redirecting users to 3DS' page (PurchasingView => 3DS)
-
 export const THREEDS_SUCCESS_REDIRECT_DELAY_MS = 5000; // Success page redirects users automatically after 5 seconds (SuccessView => ConfirmationView)

--- a/app/src/lib/domain/errors/errors.constants.ts
+++ b/app/src/lib/domain/errors/errors.constants.ts
@@ -4,7 +4,7 @@ import { withFullNameErrorMessage } from "../../utils/validationUtils";
 
 export const BUILT_IN_ERRORS = ["EvalError", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError", "AggregateError", "InternalError"];
 
-export const DEFAULT_ERROR_AT = "payment";
+export const DEFAULT_ERROR_AT = "reset";
 
 export interface MappedError {
   errorLocation?: CheckoutModalErrorAt;
@@ -17,7 +17,7 @@ export interface ErrorCreator {
   errorMessage: string;
 }
 
-function createError(errorMessage: string, at: CheckoutModalErrorAt = DEFAULT_ERROR_AT): ErrorCreator {
+function createError(errorMessage: string, at: CheckoutModalErrorAt): ErrorCreator {
   const errorCreator: ErrorCreator = (error?: ApolloError | Error): CheckoutModalError => ({
     error,
     errorMessage,
@@ -32,59 +32,54 @@ function createError(errorMessage: string, at: CheckoutModalErrorAt = DEFAULT_ER
 
 // Generic:
 
-export const ERROR_GENERIC = createError("An unexpected error happened.");
+export const ERROR_GENERIC = createError("An unexpected error happened.", "close");
 
-export const ERROR_LOADING = createError("Loading error details...");
+export const ERROR_LOADING = createError("Loading error details...", "close");
+
+export const ERROR_LOADING_TIMEOUT = createError("The purchase could not be completed.", "payment");
 
 
 // CheckoutModal:
 
-export const ERROR_LOADING_USER = createError("User could not be loaded.", "billing");
+export const ERROR_LOADING_USER = createError("User could not be loaded.", "reset");
 
-export const ERROR_LOADING_PAYMENT_METHODS = createError("Payment methods could not be loaded.", "billing");
+export const ERROR_LOADING_PAYMENT_METHODS = createError("Payment methods could not be loaded.", "reset");
 
-export const ERROR_LOADING_INVOICE = createError("Invoice could not be loaded.", "billing");
+export const ERROR_LOADING_INVOICE = createError("Invoice could not be loaded.", "reset");
 
-
-// PurchasingView:
-
-export const ERROR_PURCHASE = createError("The purchase could not be completed.");
-
-export const ERROR_PURCHASE_TIMEOUT = createError("The purchase could not be completed in time.");
+export const ERROR_INVOICE_TIMEOUT = createError("Your product reservation expired. Please, try to complete the purchase again in time.", "reset");
 
 
-// useFullPayment:
+// PurchasingView / useFullPayment:
 
-export const ERROR_PURCHASE_NO_ITEMS = createError("No items to purchase.");
+export const ERROR_PURCHASE_TIMEOUT = createError("The purchase could not be completed in time.", "purchasing");
 
-export const ERROR_PURCHASE_NO_UNITS = createError("No units to purchase.");
+export const ERROR_PURCHASE_NO_ITEMS = createError("No items to purchase.", "close");
 
-export const ERROR_PURCHASE_LOADING_ITEMS = createError("Purchase items could not be loaded.");
+export const ERROR_PURCHASE_NO_UNITS = createError("No units to purchase.", "close");
 
-export const ERROR_PURCHASE_SELECTED_PAYMENT_METHOD = createError("Could not find the selected payment method.", "payment");
-
-export const ERROR_PURCHASE_CREATING_PAYMENT_METHOD = createError("Payment method could not be saved.", "billing");
+export const ERROR_PURCHASE_LOADING_ITEMS = createError("Purchase items could not be loaded.", "close");
 
 export const ERROR_PURCHASE_CREATING_INVOICE = createError("Invoice could not be created.", "reset");
 
-export const ERROR_PURCHASE_CVV = createError("Could not verify CVV.");
+export const ERROR_PURCHASE_SELECTED_PAYMENT_METHOD = createError("Could not find the selected payment method.", "reset");
 
-export const ERROR_PURCHASE_PAYING = createError("Payment failed.");
+export const ERROR_PURCHASE_CREATING_PAYMENT_METHOD = createError("Payment method could not be saved.", "billing");
 
-export const ERROR_PURCHASE_3DS = createError("Payment method could not be verified.", "payment");
+export const ERROR_PURCHASE_CVV = createError("Could not verify CVV.", "payment");
 
-export const ERROR_INVOICE_TIMEOUT = createError("Your product reservation expired. Please, try to complete the purchase again in time.", "reset");
+export const ERROR_PURCHASE_PAYING = createError("Payment failed.", "purchasing");
 
 
 // MAPPED ERRORS:
 
 export const MAPPED_ERRORS: Record<string, MappedError> = {
   "lot auction not started": {
-    errorLocation: "reset",
+    errorLocation: "close",
     errorMessage: "The auction has not started yet.",
   },
   "payment limit exceeded": {
-    errorLocation: "reset",
+    errorLocation: "close",
     errorMessage: "You have already bought the maximum number of NFTs allowed for this sale.",
   },
   "name should contains first and last name": {

--- a/app/src/lib/hooks/useFullPayment.ts
+++ b/app/src/lib/hooks/useFullPayment.ts
@@ -23,6 +23,7 @@ export interface UseFullPaymentOptions {
 
 export interface FullPaymentState {
   paymentStatus: PaymentStatus;
+  paymentMethodID: string;
   processorPaymentID: string;
   paymentID: string;
   paymentError?: string | CheckoutModalError;
@@ -38,6 +39,7 @@ export function useFullPayment({
 }: UseFullPaymentOptions): [FullPaymentState, () => Promise<void>] {
   const [paymentState, setPaymentState] = useState<FullPaymentState>({
     paymentStatus: "processing",
+    paymentMethodID: "",
     processorPaymentID: "",
     paymentID: "",
   });
@@ -45,6 +47,7 @@ export function useFullPayment({
   const setError = useCallback((paymentError: string | CheckoutModalError) => {
     setPaymentState({
       paymentStatus: "error",
+      paymentMethodID: "",
       processorPaymentID: "",
       paymentID: "",
       paymentError,
@@ -91,6 +94,7 @@ export function useFullPayment({
 
     setPaymentState({
       paymentStatus: "processing",
+      paymentMethodID: "",
       processorPaymentID: "",
       paymentID: "",
     });
@@ -224,6 +228,7 @@ export function useFullPayment({
 
     setPaymentState({
       paymentStatus: "processed",
+      paymentMethodID,
       processorPaymentID,
       paymentID,
     });

--- a/app/src/lib/views/Error/ErrorView.tsx
+++ b/app/src/lib/views/Error/ErrorView.tsx
@@ -12,11 +12,12 @@ import { DEV_EXCEPTION_PREFIX } from "../../domain/errors/exceptions.constants";
 import { ASYNC_ERROR_MAX_WAIT_MS } from "../../config/config";
 
 const ERROR_ACTION_LABELS: Record<CheckoutModalErrorAt, string> = {
+  close: "Close",
   reset: "Try Again",
   authentication: "Review Information",
   billing: "Review Billing Information",
   payment: "Review Payment Information",
-  purchasing: "Try Again",
+  purchasing: "Retry Payment",
 };
 
 export interface ErrorViewProps {

--- a/app/src/lib/views/Purchasing/PurchasingView.tsx
+++ b/app/src/lib/views/Purchasing/PurchasingView.tsx
@@ -124,7 +124,7 @@ export const PurchasingView: React.FC<PurchasingViewProps> = ({
   }, [fullPayment]);
 
   useEffect(() => {
-    const { paymentStatus, processorPaymentID, paymentID, paymentError } = fullPaymentState;
+    const { paymentStatus, paymentMethodID, processorPaymentID, paymentID, paymentError } = fullPaymentState;
 
     if (paymentStatus === "processing") {
       onDialogBlocked(true);
@@ -152,7 +152,7 @@ export const PurchasingView: React.FC<PurchasingViewProps> = ({
         processorPaymentID,
         paymentID,
         billingInfo,
-        paymentInfo: typeof paymentInfo === "string" ? paymentInfo : null,
+        paymentInfo: typeof paymentInfo === "string" ? paymentInfo : paymentMethodID,
         checkoutItems,
       });
     }


### PR DESCRIPTION
- Fixes error handling actions: retry, etc.
- Adds new error handling action: close.
- Fixes `getCheckoutModalState` (3DS flow) not working properly for newly created payment methods. 
- Updates README section about errors / error handling.
- Adds proper error handling for loading saved payment methods error with option to reload.
- Fixes `StateSelector` reset logic (when changing the country) or going back from `PaymentView` to `BillingView`.
